### PR TITLE
Add 'repeat' argument to playback command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
 ### [Unreleased]
 - New
   - Added Sublime Text Keymap support. [#18](https://github.com/tshino/vscode-kb-macro/issues/18)
-  - Added 'repeat' argument support to the playback command.
+  - Added 'repeat' argument support to the playback command. [#19](https://github.com/tshino/vscode-kb-macro/pull/19)
 - Update
   - Updated keymap wrapper for Vz Keymap; Removed unnecessary wrappers for Vz Keymap's built-in macro feature.
 - Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
 ### [Unreleased]
 - New
   - Added Sublime Text Keymap support. [#18](https://github.com/tshino/vscode-kb-macro/issues/18)
+  - Added 'repeat' argument support to the playback command.
 - Update
   - Updated keymap wrapper for Vz Keymap; Removed unnecessary wrappers for Vz Keymap's built-in macro feature.
 - Fix

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -121,13 +121,17 @@ const KeyboardMacro = function({ awaitController }) {
         return ok;
     };
 
-    const playback = makeGuardedCommand(async function() {
+    const playback = makeGuardedCommand(async function(args) {
         if (!recording) {
+            args = (args && typeof(args) === 'object') ? args : {};
+            const repeat = typeof(args.repeat) === 'number' ? args.repeat : 1;
             const commands = sequence.get();
-            for (const spec of commands) {
-                const ok = await invokeCommandSync(spec, 'playback');
-                if (!ok) {
-                    break;
+            for (let k = 0; k < repeat; k++) {
+                for (const spec of commands) {
+                    const ok = await invokeCommandSync(spec, 'playback');
+                    if (!ok) {
+                        break;
+                    }
                 }
             }
         }

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -126,9 +126,10 @@ const KeyboardMacro = function({ awaitController }) {
             args = (args && typeof(args) === 'object') ? args : {};
             const repeat = typeof(args.repeat) === 'number' ? args.repeat : 1;
             const commands = sequence.get();
-            for (let k = 0; k < repeat; k++) {
+            let ok = true;
+            for (let k = 0; k < repeat && ok; k++) {
                 for (const spec of commands) {
-                    const ok = await invokeCommandSync(spec, 'playback');
+                    ok = await invokeCommandSync(spec, 'playback');
                     if (!ok) {
                         break;
                     }

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -224,6 +224,25 @@ describe('KeybaordMacro', () => {
                 'end'
             ]);
         });
+        it('should repeat 5 times (repeat argument)', async () => {
+            keyboardMacro.startRecording();
+            keyboardMacro.push({ command: 'internal:log' });
+            keyboardMacro.finishRecording();
+
+            await keyboardMacro.playback({ repeat: 5 });
+            assert.deepStrictEqual(logs, [
+                'begin',
+                'end',
+                'begin',
+                'end',
+                'begin',
+                'end',
+                'begin',
+                'end',
+                'begin',
+                'end'
+            ]);
+        });
         it('should abort playback if command execution failed', async () => {
             keyboardMacro.startRecording();
             keyboardMacro.push({ command: 'internal:log' });

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -253,6 +253,15 @@ describe('KeybaordMacro', () => {
             await keyboardMacro.playback();
             assert.deepStrictEqual(logs, [ 'begin', 'end' ]);
         });
+        it('should abort playback with repeat argument if command execution failed', async () => {
+            keyboardMacro.startRecording();
+            keyboardMacro.push({ command: 'internal:log' });
+            keyboardMacro.push({ command: 'INVALID' });
+            keyboardMacro.finishRecording();
+
+            await keyboardMacro.playback({ repeat: 5 });
+            assert.deepStrictEqual(logs, [ 'begin', 'end' ]);
+        });
         it('should prevent reentry', async () => {
             keyboardMacro.startRecording();
             keyboardMacro.push({ command: 'internal:log' });


### PR DESCRIPTION
This PR adds new 'repeat' argument support to the playback command `kb-macro.playback`.
Example usage in `keybindings.json`:
```
{
    "key": "ctrl+alt+5",
    "command": "kb-macro.playback",
    "args": { "repeat": 5 },
    "when": "!kb-macro.recording"
}
```
It performs the recorded sequence 5 times.