### PR TITLE
Add comment lines to keymap wrapper files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Keyboard Macro Bata extension will be documented in this file.
 
+### [Unreleased]
+- Update
+  - Added comment lines to keymap wrapper files to describe keymap name and its version.
+
 ### [0.6.0] - 2021-12-19
 - New
   - Added Sublime Text Keymap support. [#18](https://github.com/tshino/vscode-kb-macro/issues/18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
 
 ### [Unreleased]
 - Update
-  - Added comment lines to keymap wrapper files to describe keymap name and its version.
+  - Added comment lines to keymap wrapper files to describe keymap name and its version. [#20](https://github.com/tshino/vscode-kb-macro/pull/20)
 
 ### [0.6.0] - 2021-12-19
 - New

--- a/generator/gen_keymap_wrapper.js
+++ b/generator/gen_keymap_wrapper.js
@@ -50,7 +50,9 @@ async function makeKeymapWrapper(configPath, commonConfig) {
     const id = path.basename(configPath, '.config.json');
     const packageJsonPath = path.resolve(dirname, 'tmp/' + id + '.package.json');
     const packageJson = await genWrapperUtil.readJSON(packageJsonPath);
-    console.log('** generating keymap wrapper for', { id, displayName: packageJson['displayName'] });
+    const displayName = packageJson['displayName'];
+    const version = packageJson['version'];
+    console.log('** generating keymap wrapper for', { id, displayName, version });
 
     const config = await genWrapperUtil.readJSON(configPath);
 
@@ -102,7 +104,16 @@ async function makeKeymapWrapper(configPath, commonConfig) {
     );
 
     const wrapperPath = path.resolve(dirname, id + '.json');
-    await genWrapperUtil.writeCompactKeybindingsJSON(wrapperPath, wrapperKeybindings);
+    const compactJson = genWrapperUtil.makeCompactKeybindingsJSON(wrapperKeybindings);
+    const fileContent = compactJson.replace(
+        /^\[\n/,
+        (
+            '[\n' +
+            `\t// Keymap wrapper for ${displayName} v${version}\n` +
+            '\t// (required by Keyboard Macro Beta)\n'
+        )
+    ) + '\n';
+    await genWrapperUtil.writeFile(wrapperPath, fileContent);
     console.log('...done (' + id + '.json)');
 }
 

--- a/generator/gen_wrapper_util.js
+++ b/generator/gen_wrapper_util.js
@@ -18,7 +18,11 @@ async function writeJSON(path, value) {
     await fsPromises.writeFile(path, json + '\n');
 }
 
-async function writeCompactKeybindingsJSON(path, keybindings) {
+async function writeFile(path, content) {
+    await fsPromises.writeFile(path, content);
+}
+
+function makeCompactKeybindingsJSON(keybindings) {
     const json = JSON.stringify(keybindings, null, '\t');
     const compactJson = json.replace(
         /,\n\s+"(?!when)/gm, ', "'
@@ -31,7 +35,7 @@ async function writeCompactKeybindingsJSON(path, keybindings) {
     ).replace(
         /\s*\n\s+}/gm, ' }'
     );
-    await fsPromises.writeFile(path, compactJson + '\n');
+    return compactJson;
 }
 
 function addWhenContext(when, context) {
@@ -226,7 +230,8 @@ function makeWrapper(keybinding, awaitOption) {
 module.exports = {
     readJSON,
     writeJSON,
-    writeCompactKeybindingsJSON,
+    writeFile,
+    makeCompactKeybindingsJSON,
     addWhenContext,
     copyKeybinding,
     removeOSSpecificKeys,

--- a/keymap-wrapper/ms-vscode.sublime-keybindings.json
+++ b/keymap-wrapper/ms-vscode.sublime-keybindings.json
@@ -1,4 +1,6 @@
 [
+	// Keymap wrapper for Sublime Text Keymap and Settings Importer v4.0.10
+	// (required by Keyboard Macro Beta)
 	{ "key": "cmd+y", "command": "kb-macro.wrap", "args": { "command": "redo" },
 		"when": "kb-macro.recording && isMac && editorTextFocus && !editorReadonly" },
 	{ "key": "ctrl+y", "command": "kb-macro.wrap", "args": { "command": "redo" },

--- a/keymap-wrapper/tshino.vz-like-keymap.json
+++ b/keymap-wrapper/tshino.vz-like-keymap.json
@@ -1,4 +1,6 @@
 [
+	// Keymap wrapper for Vz Keymap v0.18.0
+	// (required by Keyboard Macro Beta)
 	{ "key": "ctrl+s", "command": "",
 		"when": "kb-macro.recording && editorFocus" },
 	{ "key": "ctrl+s", "command": "kb-macro.wrap", "args": { "command": "vz.cursorLeft", "await": "selection" },

--- a/keymap-wrapper/tuttieee.emacs-mcx.json
+++ b/keymap-wrapper/tuttieee.emacs-mcx.json
@@ -1,4 +1,6 @@
 [
+	// Keymap wrapper for Awesome Emacs Keymap v0.36.6
+	// (required by Keyboard Macro Beta)
 	{ "key": "ctrl+u", "command": "kb-macro.wrap", "args": { "command": "emacs-mcx.universalArgument" },
 		"when": "kb-macro.recording && editorTextFocus" },
 	{ "key": "0", "command": "kb-macro.wrap", "args": { "command": "emacs-mcx.universalArgumentDigit", "args": [ 0 ] },


### PR DESCRIPTION
To make it easy to understand the keymap wrapper, which is required for users to copy and paste into `keybindings.json` manually, this PR adds comment lines to autogenerated keymap wrappers to describe itself.
```
[
	// Keymap wrapper for Vz Keymap v0.18.0
	// (required by Keyboard Macro Beta)
	{ "key": "ctrl+s", "command": "",
		"when": "kb-macro.recording && editorFocus" },
...
```
