### PR TITLE
Add emacs-style prefix arguments support with Awesome Emacs Keymap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
 - New
   - Added Delphi Keymap support. (See [Keymap Wrappers](keymap-wrapper/README.md)) [#23](https://github.com/tshino/vscode-kb-macro/pull/23)
   - Added Visual Studio Keymap support. (See [Keymap Wrappers](keymap-wrapper/README.md)) [#24](https://github.com/tshino/vscode-kb-macro/pull/24)
+  - Added emacs-style prefix-arguments support through the keymap wrapper for Awesome Emacs Keymap. (See [Keymap Wrappers](keymap-wrapper/README.md)) [#25](https://github.com/tshino/vscode-kb-macro/pull/25)
 - Update
   - (Internal) Added colors to warnings and errors on the console output of generator scripts.
 

--- a/keymap-wrapper/README.md
+++ b/keymap-wrapper/README.md
@@ -17,7 +17,7 @@ Click the keymap wrapper link in the table below, which opens a JSON file. Copy 
 | Keymap extension | Keymap wrapper | Last updated | Start recording | Stop recording | Playback |
 | ---------------- | -------------- | ------------ | ---------- | --------- | -------- |
 | [Atom Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.atom-keybindings) | [link](ms-vscode.atom-keybindings.json) | 2021-12-24 | `Ctrl+Alt+R` | `Ctrl+Alt+R` | `Ctrl+Alt+P` |
-| [Awesome Emacs Keymap](https://marketplace.visualstudio.com/items?itemName=tuttieee.emacs-mcx) | [link](tuttieee.emacs-mcx.json) | 2021-12-17 | `C-x S-9` | `C-x S-0` | `C-x e` |
+| [Awesome Emacs Keymap](https://marketplace.visualstudio.com/items?itemName=tuttieee.emacs-mcx) | [link](tuttieee.emacs-mcx.json) | 2021-12-30 | `C-x S-9` | `C-x S-0` | `C-x e` |
 | [Delphi Keymap](https://marketplace.visualstudio.com/items?itemName=alefragnani.delphi-keybindings) | [link](alefragnani.delphi-keybindings.json) | 2021-12-27 | `Ctrl/Cmd+Shift+R` | `Ctrl/Cmd+Shift+R` | `Ctrl/Cmd+Shift+P` |
 | [Notepad++ Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.notepadplusplus-keybindings) | [link](ms-vscode.notepadplusplus-keybindings.json) | 2021-12-26 | `Ctrl+Shift+R` | `Ctrl+Shift+R` | `Ctrl+Shift+P` |
 | [Sublime Text Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.sublime-keybindings) | [link](ms-vscode.sublime-keybindings.json) | 2021-12-21 | `Ctrl/Cmd+Q` | `Ctrl/Cmd+Q` | `Ctrl/Cmd+Shift+Q` |
@@ -25,10 +25,13 @@ Click the keymap wrapper link in the table below, which opens a JSON file. Copy 
 | [Vz Keymap](https://marketplace.visualstudio.com/items?itemName=tshino.vz-like-keymap) | [link](tshino.vz-like-keymap.json) | 2021-12-11 | `Ctrl+_` | `Ctrl+^` | `Ctrl+^` |
 
 - Each keyboard shortcut for start/stop recording and playback is assigned to the same ones that the original editor is using, as much as possible.
-- Since Atom seems to not have macro recording functionality, I set them to the default of this extension.
-- Some shortcuts in the above table are overriding the default shortcuts of VS Code such as Command Palette (`Ctrl/Cmd+Shift+P`) unintentionally.
 - You can find the definitions of them at the bottom of each keymap wrapper file (find the `startRecording` command etc.). You can customize them as you like.
-- The `S-9` and `S-0` in the row of Awesome Emacs Keymap are meant to be `(` and `)` on the US keyboard. We had to write in such a way because VS Code seems to not allow using `(` or `)` in keybindings.
+- Some shortcuts in the above table are overriding the default shortcuts of VS Code such as Command Palette (`Ctrl/Cmd+Shift+P`) unintentionally.
+- Notes on **Atom Keymap**:
+    - Since Atom seems to not have macro recording functionality, the shortcuts in the keymap wrapper are set as the same as the default of this extension.
+- Notes on **Awesome Emacs Keymap**:
+    - You can also use the emacs-style prefix-arguments with the playback command! For example `C-u 7 C-x e` will playback the sequence 7 times. Please be sure that you are using the Awesome Emacs Keymap v0.37.0 or later. Thanks to [@whitphx (Tsuchiya)](https://github.com/whitphx) for the collaborative work!
+    - The `S-9` (`shift+9`) and `S-0` (`shift+0`) in the table are meant to be `(` and `)` respectively on the US keyboard. We had to write them in such a way because VS Code seems to not allow using `(` or `)` in keybindings. If your keyboard has a different layout, please adjust the keybindings by yourself.
 
 ## Making a Keymap Wrapper
 

--- a/keymap-wrapper/tuttieee.emacs-mcx.config.json
+++ b/keymap-wrapper/tuttieee.emacs-mcx.config.json
@@ -1,7 +1,7 @@
 {
     "base": {
         "type": "url",
-        "url": "https://github.com/whitphx/vscode-emacs-mcx/raw/v0.36.6/package.json"
+        "url": "https://github.com/whitphx/vscode-emacs-mcx/raw/v0.37.0/package.json"
     },
     "awaitOptions": [
         [ "emacs-mcx.forwardChar", "selection" ],
@@ -68,6 +68,15 @@
             "key": "ctrl+x e",
             "command": "kb-macro.playback",
             "when": "!kb-macro.recording"
+        },
+        {
+            "key": "ctrl+x e",
+            "command": "emacs-mcx.executeCommandWithPrefixArgument",
+            "args": {
+                "command": "kb-macro.playback",
+                "prefixArgumentKey": "repeat"
+            },
+            "when": "!kb-macro.recording && emacs-mcx.prefixArgumentExists"
         }
     ]
 }

--- a/keymap-wrapper/tuttieee.emacs-mcx.json
+++ b/keymap-wrapper/tuttieee.emacs-mcx.json
@@ -1,5 +1,5 @@
 [
-	// Keymap wrapper for Awesome Emacs Keymap v0.36.6
+	// Keymap wrapper for Awesome Emacs Keymap v0.37.0
 	// (required by Keyboard Macro Beta)
 	{ "key": "ctrl+u", "command": "kb-macro.wrap", "args": { "command": "emacs-mcx.universalArgument" },
 		"when": "kb-macro.recording && editorTextFocus" },
@@ -1218,5 +1218,7 @@
 	{ "key": "ctrl+x shift+0", "command": "kb-macro.finishRecording",
 		"when": "kb-macro.recording" },
 	{ "key": "ctrl+x e", "command": "kb-macro.playback",
-		"when": "!kb-macro.recording" }
+		"when": "!kb-macro.recording" },
+	{ "key": "ctrl+x e", "command": "emacs-mcx.executeCommandWithPrefixArgument", "args": { "command": "kb-macro.playback", "prefixArgumentKey": "repeat" },
+		"when": "!kb-macro.recording && emacs-mcx.prefixArgumentExists" }
 ]


### PR DESCRIPTION
Ref. https://github.com/whitphx/vscode-emacs-mcx/issues/1146
