### PR TITLE
Reenable test on macOS in GitHub Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [14.x]
 
     runs-on: ${{ matrix.os }}
@@ -30,6 +30,11 @@ jobs:
     - name: Run tests (Linux)
       run: xvfb-run -a npm run test
       if: runner.os == 'Linux'
-    - name: Run tests (Windows, macOS)
+    - name: Run tests (macOS)
+      run: |
+        node generator/_patch_for_ci_on_macos.js
+        npm run test
+      if: runner.os == 'macOS'
+    - name: Run tests (Windows)
       run: npm run test
-      if: runner.os != 'Linux'
+      if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Keyboard Macro Bata extension will be documented in this file.
 
+### [Unreleased]
+- Fix
+  - Reenabled running tests with macOS runners on GitHub Actions. [#28](https://github.com/tshino/vscode-kb-macro/pull/28)
+
 ### [0.8.0] - 2022-01-01
 - New
   - Added Delphi Keymap support. (See [Keymap Wrappers](keymap-wrapper/README.md)) [#23](https://github.com/tshino/vscode-kb-macro/pull/23)

--- a/generator/_patch_for_ci_on_macos.js
+++ b/generator/_patch_for_ci_on_macos.js
@@ -1,0 +1,12 @@
+'use strict';
+const { readJSON, writeJSON } = require('./gen_wrapper_util');
+
+// This script removes the content in the 'keybindings' section of the package.json.
+// This is executed before running tests on GitHub Actions with macOS runners.
+// See: https://github.com/tshino/vscode-kb-macro/pull/4
+(async () => {
+    const PackageJsonPath = './package.json';
+    const packageJson = await readJSON(PackageJsonPath);
+    packageJson['contributes']['keybindings'] = [];
+    await writeJSON(PackageJsonPath, packageJson);
+})();


### PR DESCRIPTION
This workaround adds a patch that removes the content in the 'keybindings' section of the package.json before running tests on GitHub Actions with macOS runners.
This patch won't affect the tests actually because they are not relying on the 'keybindings' section.
See #4
