### PR TITLE
Fix code completion with replacing characters to the right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
 - Update
   - Updated keymap wrapper for Awesome Emacs Keymap (v0.37.1).
 - Fix
+  - Some types of code completion were not being reproduced correctly. [#30](https://github.com/tshino/vscode-kb-macro/pull/30)
   - Reenabled running tests with macOS runners on GitHub Actions. [#28](https://github.com/tshino/vscode-kb-macro/pull/28)
 
 ### [0.8.0] - 2022-01-01

--- a/test/suite/command_sequence.test.js
+++ b/test/suite/command_sequence.test.js
@@ -69,7 +69,7 @@ describe('CommandSequence', () => {
             seq.optimize();
             assert.deepStrictEqual(seq.get(), [ TYPE123 ]);
         });
-        it('should not concatenate direct typing commands with deleting', () => {
+        it('should not concatenate direct typing commands with deleting (1)', () => {
             const TYPE1 = {
                 command: 'internal:performType',
                 args: { text: 'X' }
@@ -84,7 +84,22 @@ describe('CommandSequence', () => {
             seq.optimize();
             assert.deepStrictEqual(seq.get(), [ TYPE1, TYPE2 ]);
         });
-        it('should concatenate direct typing followed by another typing with deleting', () => {
+        it('should not concatenate direct typing commands with deleting (2)', () => {
+            const TYPE1 = {
+                command: 'internal:performType',
+                args: { text: 'X' }
+            };
+            const TYPE2 = {
+                command: 'internal:performType',
+                args: { deleteRight: 2, text: 'ABC' }
+            };
+            const seq = CommandSequence();
+            seq.push(TYPE1);
+            seq.push(TYPE2);
+            seq.optimize();
+            assert.deepStrictEqual(seq.get(), [ TYPE1, TYPE2 ]);
+        });
+        it('should concatenate direct typing followed by another typing with deleting to the left', () => {
             const TYPE1 = {
                 command: 'internal:performType',
                 args: { text: 'a' }
@@ -108,7 +123,7 @@ describe('CommandSequence', () => {
             seq.optimize();
             assert.deepStrictEqual(seq.get(), [ TYPE123 ]);
         });
-        it('should concatenate direct typing with deleting followed by another typing without deleting', () => {
+        it('should concatenate direct typing with deleting followed by another typing without deleting (1)', () => {
             const TYPE1 = {
                 command: 'internal:performType',
                 args: { deleteLeft: 1, text: 'a' }
@@ -120,6 +135,25 @@ describe('CommandSequence', () => {
             const TYPE12 = {
                 command: 'internal:performType',
                 args: { deleteLeft: 1, text: 'ab' }
+            };
+            const seq = CommandSequence();
+            seq.push(TYPE1);
+            seq.push(TYPE2);
+            seq.optimize();
+            assert.deepStrictEqual(seq.get(), [ TYPE12 ]);
+        });
+        it('should concatenate direct typing with deleting followed by another typing without deleting (2)', () => {
+            const TYPE1 = {
+                command: 'internal:performType',
+                args: { deleteRight: 1, text: 'a' }
+            };
+            const TYPE2 = {
+                command: 'internal:performType',
+                args: { text: 'b' }
+            };
+            const TYPE12 = {
+                command: 'internal:performType',
+                args: { deleteRight: 1, text: 'ab' }
             };
             const seq = CommandSequence();
             seq.push(TYPE1);
@@ -201,6 +235,25 @@ describe('CommandSequence', () => {
             seq.push(MOVE2);
             seq.optimize();
             assert.deepStrictEqual(seq.get(), [ MOVE1, MOVE2 ]);
+        });
+        it('should combine cursor motion to the left and successive typing with deleting to the right', () => {
+            const TYPE1 = {
+                command: 'internal:performCursorMotion',
+                args: { characterDelta: -1 }
+            };
+            const TYPE2 = {
+                command: 'internal:performType',
+                args: { deleteRight: 1, text: 'a' }
+            };
+            const TYPE12 = {
+                command: 'internal:performType',
+                args: { deleteLeft: 1, text: 'a' }
+            };
+            const seq = CommandSequence();
+            seq.push(TYPE1);
+            seq.push(TYPE2);
+            seq.optimize();
+            assert.deepStrictEqual(seq.get(), [ TYPE12 ]);
         });
     });
 });

--- a/test/suite/playback_typing.test.js
+++ b/test/suite/playback_typing.test.js
@@ -10,6 +10,7 @@ describe('Recording and Playback: Typing', () => {
     let textEditor;
     const Cmd = CommandsToTest;
     const Type = text => ({ command: 'internal:performType', args: { text } });
+    const ReplaceRight = (deleteRight, text) => ({ command: 'internal:performType', args: { deleteRight, text } });
     const DefaultType = text => ({ command: 'default:type', args: { text } });
     const MoveLeft = delta => ({ command: 'internal:performCursorMotion', args: { characterDelta: -delta } });
     const MoveRight = delta => ({ command: 'internal:performCursorMotion', args: { characterDelta: delta } });
@@ -279,7 +280,7 @@ describe('Recording and Playback: Typing', () => {
             await vscode.commands.executeCommand('type', { text: '10' });
             await vscode.commands.executeCommand('type', { text: ')' }); // This overwrites the closing bracket.
             keyboardMacro.finishRecording();
-            assert.deepStrictEqual(getSequence(), [ Type('()'), MoveLeft(1), Type('10'), MoveRight(1) ]);
+            assert.deepStrictEqual(getSequence(), [ Type('()'), MoveLeft(1), Type('10'), ReplaceRight(1, ')') ]);
             assert.strictEqual(textEditor.document.lineAt(5).text, '(10)');
             assert.deepStrictEqual(getSelections(), [[5, 4]]);
 
@@ -295,7 +296,7 @@ describe('Recording and Playback: Typing', () => {
             await vscode.commands.executeCommand('type', { text: '10' });
             await vscode.commands.executeCommand('type', { text: ')' }); // This overwrites the closing bracket.
             keyboardMacro.finishRecording();
-            assert.deepStrictEqual(getSequence(), [ Type('()'), MoveLeft(1), Type('10'), MoveRight(1) ]);
+            assert.deepStrictEqual(getSequence(), [ Type('()'), MoveLeft(1), Type('10'), ReplaceRight(1, ')') ]);
             assert.strictEqual(textEditor.document.lineAt(5).text, '(10)');
             assert.strictEqual(textEditor.document.lineAt(6).text, '(10)');
             assert.deepStrictEqual(getSelections(), [[5, 4], [6, 4]]);

--- a/test/suite/typing_detector.test.js
+++ b/test/suite/typing_detector.test.js
@@ -285,6 +285,13 @@ describe('TypingDetector', () => {
             expectedLogs: [[0, {text:'EFGHI', deleteLeft:4}]],
             expectedPrediction: [[20, 9]] });
         });
+        it('should process events, detect code completion and invoke the callback function (3)', async () => {
+            testDetection({ changes: [
+                makeContentChange(new vscode.Range(20, 4, 20, 6), '"key": ""')
+            ], precond: [[20, 5]],
+            expectedLogs: [[0, {text:'"key": ""', deleteLeft:1, deleteRight:1}]],
+            expectedPrediction: [[20, 13]] });
+        });
         it('should not make prediction if no change is expected', async () => {
             testDetection({ changes: [
                 makeContentChange(new vscode.Range(10, 0, 10, 4), 'Abcd')


### PR DESCRIPTION
Reproducing steps:
1. open `package.json`
2. place the cursor inside `contributes.commands` section
3. type `"`
4. automatically get the closing `"` inserted
5. automatically get a suggestion `category": "` (the key depends on the context) inside the two quotes.
6. hit TAB to accept the suggestion
7. get resulted text `"category", ""`
8. record the above sequence from 2 to 7 and then try playback at another location.

This type of code completion replaces the quotes `""` surrounding the cursor with the suggested text.
Detecting this type of code completion is not supported in the current implementation of TypingDetector.
This PR adds the capability of detecting that type of code completion to fix the issue.