### PR TITLE
Make 'wrap' command queueable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the Keyboard Macro Bata extension will be documented in this file.
 
 ### [Unreleased]
+- Feature
+  - Made the `kb-macro.wrap` command queueable to reduce input misses during recording. [#32](https://github.com/tshino/vscode-kb-macro/pull/32)
 - Documentation
   - Added 'Tips' section to the README.
 

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -189,6 +189,7 @@ const KeyboardMacro = function({ awaitController }) {
     // min value is 1.
     // greater value reduces input rejection. 2 or 3 is enough.
     // greater value leads to too many queued and delayed command execution.
+    // See: https://github.com/tshino/vscode-kb-macro/pull/32
     const WrapQueueSize = 2;
     const wrap = reentrantGuard.makeQueueableCommand(async function(args) {
         if (recording) {

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -184,7 +184,13 @@ const KeyboardMacro = function({ awaitController }) {
         return spec;
     };
 
-    const wrap = reentrantGuard.makeGuardedCommand(async function(args) {
+    // WrapQueueSize
+    // independently adjustable value.
+    // min value is 1.
+    // greater value reduces input rejection. 2 or 3 is enough.
+    // greater value leads to too many queued and delayed command execution.
+    const WrapQueueSize = 2;
+    const wrap = reentrantGuard.makeQueueableCommand(async function(args) {
         if (recording) {
             const spec = makeCommandSpec(args);
             if (!spec) {
@@ -204,7 +210,7 @@ const KeyboardMacro = function({ awaitController }) {
                 }
             }
         }
-    });
+    }, { queueSize: WrapQueueSize });
 
     return {
         RecordingStateReason,
@@ -228,7 +234,8 @@ const KeyboardMacro = function({ awaitController }) {
         isRecording: () => { return recording; },
         isPlaying: () => { return playing; },
         getCurrentSequence: () => { return sequence.get(); },
-        setShowInputBox // testing purpose only
+        setShowInputBox,
+        WrapQueueSize
     };
 };
 

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -551,7 +551,7 @@ describe('KeybaordMacro', () => {
                 { command: 'internal:log', args: { test: '1' } }
             ]);
         });
-        it('should enqueue and serialize concurrent call', async () => {
+        it('should enqueue and serialize concurrent calls', async () => {
             keyboardMacro.startRecording();
             const promise1 = keyboardMacro.wrap({ command: 'internal:log' });
             const promise2 = keyboardMacro.wrap({ command: 'internal:log' });


### PR DESCRIPTION
In current implementation (v0.9.0), the `kb-macro.wrap` command rejects concurrent calls.
When keystrokes occurred faster than command executions, some of them are discarded.
As a result, the user is required to retry the failed inputs or to type shortcut keys slowly to avoid rejection.

The rejection was intended to stop the concurrent execution of commands.

This PR introduces command queueing so that the rejection becomes less likely to occur.