### PR TITLE
Rename internal commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
   - Made the `kb-macro.wrap` command queueable to reduce input misses during recording. [#32](https://github.com/tshino/vscode-kb-macro/pull/32)
 - Documentation
   - Added 'Tips' section to the README.
+- Internal
+  - Renamed internal commands. [#39](https://github.com/tshino/vscode-kb-macro/pull/39)
+    - `internal:performType` -> `$type`
+    - `internal:performCursorMotion` -> `$moveCursor`
 
 ### [0.9.0] - 2022-01-6
 - New

--- a/src/command_sequence.js
+++ b/src/command_sequence.js
@@ -38,7 +38,7 @@ const CommandSequence = function() {
             // Combine cursor motion to the left and successive typing with deleting to the right
             if (i + 1 < sequence.length &&
                 sequence[i].command === 'internal:performCursorMotion' &&
-                sequence[i + 1].command === 'internal:performType') {
+                sequence[i + 1].command === '$type') {
                 const args1 = sequence[i].args || {};
                 const args2 = sequence[i + 1].args || {};
                 const characterDelta1 = args1.characterDelta || 0;
@@ -61,8 +61,8 @@ const CommandSequence = function() {
             }
             // Concatenate consecutive direct typing
             if (0 < i &&
-                sequence[i - 1].command === 'internal:performType' &&
-                sequence[i].command === 'internal:performType'
+                sequence[i - 1].command === '$type' &&
+                sequence[i].command === '$type'
             ) {
                 const args1 = sequence[i - 1].args || {};
                 const args2 = sequence[i].args || {};

--- a/src/command_sequence.js
+++ b/src/command_sequence.js
@@ -13,8 +13,8 @@ const CommandSequence = function() {
         for (let i = 0; i < sequence.length; i++) {
             // Remove a pair of cursor movement that results nothing
             if (i + 1 < sequence.length &&
-                sequence[i].command === 'internal:performCursorMotion' &&
-                sequence[i + 1].command === 'internal:performCursorMotion') {
+                sequence[i].command === '$moveCursor' &&
+                sequence[i + 1].command === '$moveCursor') {
                 const args1 = sequence[i].args || {};
                 const args2 = sequence[i + 1].args || {};
                 const characterDelta1 = args1.characterDelta || 0;
@@ -37,7 +37,7 @@ const CommandSequence = function() {
             }
             // Combine cursor motion to the left and successive typing with deleting to the right
             if (i + 1 < sequence.length &&
-                sequence[i].command === 'internal:performCursorMotion' &&
+                sequence[i].command === '$moveCursor' &&
                 sequence[i + 1].command === '$type') {
                 const args1 = sequence[i].args || {};
                 const args2 = sequence[i + 1].args || {};

--- a/src/extension.js
+++ b/src/extension.js
@@ -36,7 +36,7 @@ function activate(context) {
     registerCommand('repeatPlayback', keyboardMacro.repeatPlayback);
     registerCommand('wrap', keyboardMacro.wrap);
 
-    keyboardMacro.registerInternalCommand('internal:performType', internalCommands.performType);
+    keyboardMacro.registerInternalCommand('$type', internalCommands.performType);
     keyboardMacro.registerInternalCommand('internal:performCursorMotion', internalCommands.performCursorMotion);
 
     const modeIndicator = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 110);
@@ -124,7 +124,7 @@ function activate(context) {
         function(type, args) {
             if (type === typingDetector.TypingType.Direct) {
                 keyboardMacro.push({
-                    command: 'internal:performType',
+                    command: '$type',
                     args: args
                 });
             } else if (type === typingDetector.TypingType.Default) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -37,7 +37,7 @@ function activate(context) {
     registerCommand('wrap', keyboardMacro.wrap);
 
     keyboardMacro.registerInternalCommand('$type', internalCommands.performType);
-    keyboardMacro.registerInternalCommand('internal:performCursorMotion', internalCommands.performCursorMotion);
+    keyboardMacro.registerInternalCommand('$moveCursor', internalCommands.performCursorMotion);
 
     const modeIndicator = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 110);
     modeIndicator.text = "REC";
@@ -140,7 +140,7 @@ function activate(context) {
         function(type, args) {
             if (type === typingDetector.CursorMotionType.Direct) {
                 keyboardMacro.push({
-                    command: 'internal:performCursorMotion',
+                    command: '$moveCursor',
                     args: args
                 });
             }

--- a/test/suite/command_sequence.test.js
+++ b/test/suite/command_sequence.test.js
@@ -47,19 +47,19 @@ describe('CommandSequence', () => {
         });
         it('should concatenate consecutive direct typing commands', () => {
             const TYPE1 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'A' }
             };
             const TYPE2 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'B' }
             };
             const TYPE3 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'C' }
             };
             const TYPE123 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'ABC' }
             };
             const seq = CommandSequence();
@@ -71,11 +71,11 @@ describe('CommandSequence', () => {
         });
         it('should not concatenate direct typing commands with deleting (1)', () => {
             const TYPE1 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'X' }
             };
             const TYPE2 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { deleteLeft: 2, text: 'ABC' }
             };
             const seq = CommandSequence();
@@ -86,11 +86,11 @@ describe('CommandSequence', () => {
         });
         it('should not concatenate direct typing commands with deleting (2)', () => {
             const TYPE1 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'X' }
             };
             const TYPE2 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { deleteRight: 2, text: 'ABC' }
             };
             const seq = CommandSequence();
@@ -101,19 +101,19 @@ describe('CommandSequence', () => {
         });
         it('should concatenate direct typing followed by another typing with deleting to the left', () => {
             const TYPE1 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'a' }
             };
             const TYPE2 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'b' }
             };
             const TYPE3 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { deleteLeft: 2, text: 'ABC' }
             };
             const TYPE123 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'ABC' }
             };
             const seq = CommandSequence();
@@ -125,15 +125,15 @@ describe('CommandSequence', () => {
         });
         it('should concatenate direct typing with deleting followed by another typing without deleting (1)', () => {
             const TYPE1 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { deleteLeft: 1, text: 'a' }
             };
             const TYPE2 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'b' }
             };
             const TYPE12 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { deleteLeft: 1, text: 'ab' }
             };
             const seq = CommandSequence();
@@ -144,15 +144,15 @@ describe('CommandSequence', () => {
         });
         it('should concatenate direct typing with deleting followed by another typing without deleting (2)', () => {
             const TYPE1 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { deleteRight: 1, text: 'a' }
             };
             const TYPE2 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { text: 'b' }
             };
             const TYPE12 = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { deleteRight: 1, text: 'ab' }
             };
             const seq = CommandSequence();
@@ -243,12 +243,12 @@ describe('CommandSequence', () => {
                     args: { characterDelta: -1 }
                 },
                 {
-                    command: 'internal:performType',
+                    command: '$type',
                     args: { deleteRight: 1, text: 'a' }
                 }
             ];
             const EXPECTED = {
-                command: 'internal:performType',
+                command: '$type',
                 args: { deleteLeft: 1, text: 'a' }
             };
             const seq = CommandSequence();
@@ -260,7 +260,7 @@ describe('CommandSequence', () => {
         it('should shrink three commands into one', () => {
             const INPUT = [
                 {
-                    command: 'internal:performType',
+                    command: '$type',
                     args: { text: '()' }
                 },
                 {
@@ -268,13 +268,13 @@ describe('CommandSequence', () => {
                     args: { characterDelta: -1 }
                 },
                 {
-                    command: 'internal:performType',
+                    command: '$type',
                     args: { deleteRight: 1, text: ')' }
                 }
             ];
             const EXPECTED = [
                 {
-                    command: 'internal:performType',
+                    command: '$type',
                     args: { text: '()' }
                 }
             ];

--- a/test/suite/command_sequence.test.js
+++ b/test/suite/command_sequence.test.js
@@ -163,11 +163,11 @@ describe('CommandSequence', () => {
         });
         it('should remove a pair of cursor motion that results no effect', () => {
             const MOVE1 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: -3 }
             };
             const MOVE2 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: 3 }
             };
             const seq = CommandSequence();
@@ -178,11 +178,11 @@ describe('CommandSequence', () => {
         });
         it('should retain consecutive cursor motions that have vertical motion', () => {
             const MOVE1 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: -3, lineDelta: -1 }
             };
             const MOVE2 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: 3, lineDelta: 1 }
             };
             const seq = CommandSequence();
@@ -193,11 +193,11 @@ describe('CommandSequence', () => {
         });
         it('should retain consecutive cursor motions that have selectionLength', () => {
             const MOVE1 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: -3 }
             };
             const MOVE2 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: 3, selectionLength: 5 }
             };
             const seq = CommandSequence();
@@ -208,11 +208,11 @@ describe('CommandSequence', () => {
         });
         it('should retain consecutive cursor motions that include splitting motion', () => {
             const MOVE1 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: [ 1, 2 ] }
             };
             const MOVE2 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: -1 }
             };
             const seq = CommandSequence();
@@ -223,11 +223,11 @@ describe('CommandSequence', () => {
         });
         it('should retain consecutive cursor motions that include group motion', () => {
             const MOVE1 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: 2, groupSize: 2 }
             };
             const MOVE2 = {
-                command: 'internal:performCursorMotion',
+                command: '$moveCursor',
                 args: { characterDelta: -2 }
             };
             const seq = CommandSequence();
@@ -239,7 +239,7 @@ describe('CommandSequence', () => {
         it('should combine cursor motion to the left and successive typing with deleting to the right', () => {
             const INPUT = [
                 {
-                    command: 'internal:performCursorMotion',
+                    command: '$moveCursor',
                     args: { characterDelta: -1 }
                 },
                 {
@@ -264,7 +264,7 @@ describe('CommandSequence', () => {
                     args: { text: '()' }
                 },
                 {
-                    command: 'internal:performCursorMotion',
+                    command: '$moveCursor',
                     args: { characterDelta: -1 }
                 },
                 {

--- a/test/suite/playback_typing.test.js
+++ b/test/suite/playback_typing.test.js
@@ -12,22 +12,22 @@ describe('Recording and Playback: Typing', () => {
     const Type = text => ({ command: '$type', args: { text } });
     const ReplaceRight = (deleteRight, text) => ({ command: '$type', args: { deleteRight, text } });
     const DefaultType = text => ({ command: 'default:type', args: { text } });
-    const MoveLeft = delta => ({ command: 'internal:performCursorMotion', args: { characterDelta: -delta } });
-    const MoveRight = delta => ({ command: 'internal:performCursorMotion', args: { characterDelta: delta } });
+    const MoveLeft = delta => ({ command: '$moveCursor', args: { characterDelta: -delta } });
+    const MoveRight = delta => ({ command: '$moveCursor', args: { characterDelta: delta } });
     const MoveLeftSelect = (delta, select) => ({
-        command: 'internal:performCursorMotion',
+        command: '$moveCursor',
         args: { characterDelta: -delta, selectionLength: select }
     });
     const MoveRightSelect = (delta, select) => ({
-        command: 'internal:performCursorMotion',
+        command: '$moveCursor',
         args: { characterDelta: delta, selectionLength: select }
     });
     const MoveUpSelect = (up, delta, select) => ({
-        command: 'internal:performCursorMotion',
+        command: '$moveCursor',
         args: { lineDelta: -up, characterDelta: delta, selectionLength: select }
     });
     const MoveDown = (down, delta) => ({
-        command: 'internal:performCursorMotion',
+        command: '$moveCursor',
         args: { lineDelta: down, characterDelta: delta }
     });
     const SplitMotion = (ch, ln, sel) => {
@@ -35,7 +35,7 @@ describe('Recording and Playback: Typing', () => {
         if (ln) motion.lineDelta = ln;
         if (sel) motion.selectionLength = sel;
         return {
-            command: 'internal:performCursorMotion',
+            command: '$moveCursor',
             args: motion
         };
     };

--- a/test/suite/playback_typing.test.js
+++ b/test/suite/playback_typing.test.js
@@ -9,8 +9,8 @@ const { keyboardMacro, awaitController } = require('../../src/extension.js');
 describe('Recording and Playback: Typing', () => {
     let textEditor;
     const Cmd = CommandsToTest;
-    const Type = text => ({ command: 'internal:performType', args: { text } });
-    const ReplaceRight = (deleteRight, text) => ({ command: 'internal:performType', args: { deleteRight, text } });
+    const Type = text => ({ command: '$type', args: { text } });
+    const ReplaceRight = (deleteRight, text) => ({ command: '$type', args: { deleteRight, text } });
     const DefaultType = text => ({ command: 'default:type', args: { text } });
     const MoveLeft = delta => ({ command: 'internal:performCursorMotion', args: { characterDelta: -delta } });
     const MoveRight = delta => ({ command: 'internal:performCursorMotion', args: { characterDelta: delta } });


### PR DESCRIPTION
Rename internal commands to make the names shorter and as simple as possible.

`internal:performType` -> `$type`
`internal:performCursorMotion` -> `$moveCursor`
