### PR TITLE
'copyMacroAsKeybinding' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
 
 ### [Unreleased]
 - Feature
+  - Added a new `Keyboard Macro: Copy Macro as Keybinding` command. [#42](https://github.com/tshino/vscode-kb-macro/pull/42)
   - Added `sequence` argument support to the playback command. [#41](https://github.com/tshino/vscode-kb-macro/pull/41)
 - Update
   - Updated keymap wrapper for Awesome Emacs Keymap (v0.39.0).

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This is the default keybinding set for recording/playback of this extension. Cop
 | `Start Recording` | `kb-macro.startRecording` | Start recording |
 | `Finish Recording` | `kb-macro.finishRecording` | Stop recording |
 | `Cancel Recording` | `kb-macro.cancelRecording` | Stop recording and discard the recorded sequence |
+| `Copy Macro as Keybinding` | `kb-macro.copyMacroAsKeybinding` | Copy the last recorded macro as keybinding JSON format to the clipboard |
 
 ### For playback
 | Command name | Command ID | Function |

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"onCommand:kb-macro.startRecording",
 		"onCommand:kb-macro.finishRecording",
 		"onCommand:kb-macro.cancelRecording",
+		"onCommand:kb-macro.copyMacroAsKeybinding",
 		"onCommand:kb-macro.playback",
 		"onCommand:kb-macro.abortPlayback",
 		"onCommand:kb-macro.repeatPlayback",
@@ -91,6 +92,11 @@
 			{
 				"command": "kb-macro.cancelRecording",
 				"title": "Cancel Recording",
+				"category": "Keyboard Macro"
+			},
+			{
+				"command": "kb-macro.copyMacroAsKeybinding",
+				"title": "Copy Macro as Keybinding",
 				"category": "Keyboard Macro"
 			},
 			{

--- a/src/extension.js
+++ b/src/extension.js
@@ -31,6 +31,7 @@ function activate(context) {
     registerCommand('startRecording', keyboardMacro.startRecording);
     registerCommand('cancelRecording', keyboardMacro.cancelRecording);
     registerCommand('finishRecording', keyboardMacro.finishRecording);
+    registerCommand('copyMacroAsKeybinding', keyboardMacro.copyMacroAsKeybinding);
     registerCommand('playback', keyboardMacro.playback);
     registerCommand('abortPlayback', keyboardMacro.abortPlayback);
     registerCommand('repeatPlayback', keyboardMacro.repeatPlayback);

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -88,6 +88,23 @@ const KeyboardMacro = function({ awaitController }) {
         }
     };
 
+    const copyMacroAsKeybinding = reentrantGuard.makeGuardedCommand(async function() {
+        const commands = sequence.get();
+        const macro =
+        '{\n' +
+        '    "key": "",\n' +
+        '    "command": "kb-macro.playback",\n' +
+        '    "args": {\n' +
+        '        "sequence": [\n' +
+        commands.map(
+            spec => `            ${JSON.stringify(spec, null, 1).replace(/\n\s*/g, ' ')}`
+        ).join(',\n') + (commands.length === 0 ? '' : '\n') +
+        '        ]\n' +
+        '    }\n' +
+        '}';
+        await vscode.env.clipboard.writeText(macro);
+    });
+
     const invokeCommand = async function(spec) {
         const func = internalCommands[spec.command];
         if (func !== undefined) {
@@ -242,6 +259,7 @@ const KeyboardMacro = function({ awaitController }) {
         cancelRecording,
         finishRecording,
         push,
+        copyMacroAsKeybinding,
         validatePlaybackArgs,
         playback,
         abortPlayback,

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -243,6 +243,35 @@ describe('KeybaordMacro', () => {
             assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), []);
         });
     });
+    describe('copyMacroAsKeybinding', () => {
+        beforeEach(async () => {
+            keyboardMacro.onChangeRecordingState(null);
+            keyboardMacro.cancelRecording();
+        });
+        it('should write the recorded macro to the clipboard', async () => {
+            keyboardMacro.startRecording();
+            keyboardMacro.push({ command: 'command1' });
+            keyboardMacro.push({ command: 'command2', args: 'arg2' });
+            keyboardMacro.push({ command: 'command3', args: 'arg3', 'await': 'await3' });
+            keyboardMacro.finishRecording();
+
+            await keyboardMacro.copyMacroAsKeybinding();
+            assert.strictEqual(
+                await vscode.env.clipboard.readText(),
+                '{\n' +
+                '    "key": "",\n' +
+                '    "command": "kb-macro.playback",\n' +
+                '    "args": {\n' +
+                '        "sequence": [\n' +
+                '            { "command": "command1" },\n' +
+                '            { "command": "command2", "args": "arg2" },\n' +
+                '            { "command": "command3", "args": "arg3", "await": "await3" }\n' +
+                '        ]\n' +
+                '    }\n' +
+                '}'
+            );
+        });
+    });
     describe('validatePlaybackArgs', () => {
         const validatePlaybackArgs = keyboardMacro.validatePlaybackArgs;
         it('should return an args valid for playback command', () => {


### PR DESCRIPTION
Part of #40
This PR adds a new `copyMacroAsKeybinding` command.

