### PR TITLE
Fix uncaught errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
   - Added `sequence` argument support to the playback command. [#41](https://github.com/tshino/vscode-kb-macro/pull/41)
 - Update
   - Updated keymap wrapper for Awesome Emacs Keymap (v0.39.0).
+- Fix
+  - Fixed uncaught errors 'Cannot read property 'textEditor' of undefined'. [#47](https://github.com/tshino/vscode-kb-macro/pull/47)
 
 ### [0.10.0] - 2022-01-28
 - Feature

--- a/src/extension.js
+++ b/src/extension.js
@@ -117,8 +117,8 @@ function activate(context) {
     );
     addEventListener(
         vscode.window.onDidChangeActiveTextEditor,
-        function(event) {
-            helperContext.processActiveTextEditorChangeEvent(event);
+        function(textEditor) {
+            helperContext.processActiveTextEditorChangeEvent(textEditor);
         }
     );
     addEventListener(

--- a/src/helper_context.js
+++ b/src/helper_context.js
@@ -33,8 +33,8 @@ const HelperContext = function() {
     const reset = function(textEditor) {
         update(textEditor);
     };
-    const processActiveTextEditorChangeEvent = function(event) {
-        update(event.textEditor);
+    const processActiveTextEditorChangeEvent = function(textEditor) {
+        update(textEditor);
     };
     const processSelectionChangeEvent = function(event) {
         update(event.textEditor);

--- a/test/suite/helper_context.test.js
+++ b/test/suite/helper_context.test.js
@@ -30,8 +30,7 @@ describe('HelperContext', () => {
             const textEditor1 = { selections: [ new vscode.Selection(2, 4, 2, 4) ] };
             const textEditor2 = { selections: [ new vscode.Selection(3, 0, 3, 0) ] };
             helperContext.reset(textEditor1);
-            const event = { textEditor: textEditor2 };
-            helperContext.processActiveTextEditorChangeEvent(event);
+            helperContext.processActiveTextEditorChangeEvent(textEditor2);
             assert.strictEqual(helperContext.getContext(HeadOfLine), true);
         });
     });


### PR DESCRIPTION
Sometimes I noticed uncaught errors shown in the `Runtime Status` section on the extension page.
```
Cannot read property 'textEditor' of undefined
```
![image](https://user-images.githubusercontent.com/732920/152371825-0cc2c9e2-f5f1-41e9-93cb-6aa012f1e31a.png)
This PR fixes this problem.
