### PR TITLE
Add 'record' option to 'wrap' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
   - Added 'Keymap wrappers' section to [DESIGN.md](./DESIGN.md).
 - Update
   - Updated default keybindings based on VS Code 1.65.2. [#74](https://github.com/tshino/vscode-kb-macro/pull/74)
+- Internal
+  - Added `record` option to the `kb-macro.wrap` command. [#76](https://github.com/tshino/vscode-kb-macro/pull/76)
 
 ### [0.11.3] - 2022-03-06
 - Update

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -100,6 +100,10 @@ const KeyboardMacro = function({ awaitController }) {
 
     const push = function(spec) {
         if (recording) {
+            if (spec.record === 'side-effect') {
+                // side-effect mode
+                return;
+            }
             sequence.push(spec);
         }
     };

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -287,7 +287,8 @@ const KeyboardMacro = function({ awaitController }) {
                 await playbackImpl(spec.args);
                 return;
             }
-            if (onBeginWrappedCommandCallback) {
+            const sideEffectMode = spec.record === 'side-effect';
+            if (!sideEffectMode && onBeginWrappedCommandCallback) {
                 onBeginWrappedCommandCallback();
             }
             try {
@@ -296,7 +297,7 @@ const KeyboardMacro = function({ awaitController }) {
                     push(spec);
                 }
             } finally {
-                if (onEndWrappedCommandCallback) {
+                if (!sideEffectMode && onEndWrappedCommandCallback) {
                     onEndWrappedCommandCallback();
                 }
             }

--- a/src/util.js
+++ b/src/util.js
@@ -73,6 +73,12 @@ const util = (function() {
             }
             spec['await'] = args['await'];
         }
+        if ('record' in args) {
+            if (typeof(args.record) !== 'string') {
+                return null;
+            }
+            spec.record = args.record;
+        }
         return spec;
     };
 

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -230,6 +230,9 @@ describe('KeybaordMacro', () => {
             keyboardMacro.onChangeRecordingState(null);
             keyboardMacro.cancelRecording();
         });
+        afterEach(async () => {
+            keyboardMacro.cancelRecording();
+        });
         it('should add specified command to sequence', async () => {
             keyboardMacro.startRecording();
             keyboardMacro.push({ command: 'example:command1' });
@@ -243,6 +246,13 @@ describe('KeybaordMacro', () => {
         it('should do nothing if not recording', async () => {
             keyboardMacro.push({ command: 'example:command1' });
             keyboardMacro.push({ command: 'example:command2', args: { opt1: 'opt1' } });
+
+            assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), []);
+        });
+        it('should do nothing if side-effect mode', async () => {
+            keyboardMacro.startRecording();
+            keyboardMacro.push({ command: 'example:command1', record: 'side-effect' });
+            keyboardMacro.push({ command: 'example:command2', record: 'side-effect', args: { opt1: 'opt1' } });
 
             assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), []);
         });
@@ -963,5 +973,14 @@ describe('KeybaordMacro', () => {
                 { command: 'internal:indirectWrap' }
             ]);
         });
+        it('should invoke but not record the target command if side-effect mode', async () => {
+            keyboardMacro.startRecording();
+            await keyboardMacro.wrapSync({ command: 'internal:log', record: 'side-effect' });
+            keyboardMacro.finishRecording();
+
+            assert.deepStrictEqual(logs, [ 'begin', 'end' ]);
+            assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), []);
+        });
+        // TODO: test for side-effect mode not to invoke onBegin/EndWrappedCommand
     });
 });

--- a/test/suite/util.test.js
+++ b/test/suite/util.test.js
@@ -210,6 +210,9 @@ describe('util', () => {
             assert.strictEqual(makeCommandSpec({ foo: 'foo' }), null);
             assert.strictEqual(makeCommandSpec({ command: 123 }), null);
             assert.strictEqual(makeCommandSpec({ command: 'aaa', 'await': 123  }), null);
+            assert.strictEqual(makeCommandSpec({ command: 'aaa', 'await': [ 'xxx' ]  }), null);
+            assert.strictEqual(makeCommandSpec({ command: 'aaa', record: 123  }), null);
+            assert.strictEqual(makeCommandSpec({ command: 'aaa', record: [ 'xxx' ]  }), null);
         });
         it('should return a new Object', () => {
             const input = { command: 'foo' };
@@ -237,6 +240,12 @@ describe('util', () => {
             assert.deepStrictEqual(
                 makeCommandSpec({ command: 'a', args: { b: 42 }, 'await': 'ccc' }),
                 { command: 'a', args: { b: 42 }, 'await': 'ccc' }
+            );
+        });
+        it('should accept \'record\' properties as well', () => {
+            assert.deepStrictEqual(
+                makeCommandSpec({ command: 'a', record: 'side-effect' }),
+                { command: 'a', record: 'side-effect' }
             );
         });
         it('should drop properties that are not relevant to a command spec', () => {


### PR DESCRIPTION
Part of #33.

This PR adds a new `recode` parameter to the `kb-macro.wrap` command.
If the `record` parameter has a string value `side-effect`, the `wrap` command will enable side-effect detection to capture the effect of the target command instead while not appending the target command to the sequence.

This side-effect mode of `wrap` will be used for some special commands related to IntelliSense and snippet insertion to distinguish the expected side effects of them and other unexpected ones.