### PR TITLE
Ignore untracked cursor motion

### DIFF
--- a/src/cursor_motion_detector.js
+++ b/src/cursor_motion_detector.js
@@ -8,6 +8,7 @@ const CursorMotionDetector = function() {
     };
     let onDetectCursorMotionCallback = null;
     let enabled = false;
+    let aloneEnabled = true;
     let lastSelections = null;
     let lastTextEditor = null;
     const predictions = [];
@@ -44,6 +45,9 @@ const CursorMotionDetector = function() {
     };
     const stop = function() {
         enabled = false;
+    };
+    const setAloneEnabled = function(enabled) {
+        aloneEnabled = enabled;
     };
     const setPrediction = function(textEditor, expected) {
         if (textEditorForPredictions !== textEditor) {
@@ -192,7 +196,9 @@ const CursorMotionDetector = function() {
                 //   - cursor movement that happen when the user types in the find input box
                 // We consider it an implicit cursor motion.
                 // We notify it so that it will be recorded to be able to playback.
-                notifyDetectedMotion(CursorMotionType.Alone, motion);
+                if (aloneEnabled) {
+                    notifyDetectedMotion(CursorMotionType.Alone, motion);
+                }
                 // console.log('motion without prediction');
             } else {
                 // console.log('skip');
@@ -242,6 +248,7 @@ const CursorMotionDetector = function() {
         stop,
         setPrediction,
         getPrediction,
+        setAloneEnabled,
         processSelectionChangeEvent,
 
         isEnabled: function() { return enabled; } // testing purpose only

--- a/src/cursor_motion_detector.js
+++ b/src/cursor_motion_detector.js
@@ -8,7 +8,7 @@ const CursorMotionDetector = function() {
     };
     let onDetectCursorMotionCallback = null;
     let enabled = false;
-    let aloneEnabled = true;
+    let aloneEnabled = false;
     let lastSelections = null;
     let lastTextEditor = null;
     const predictions = [];

--- a/src/extension.js
+++ b/src/extension.js
@@ -90,14 +90,22 @@ function activate(context) {
     );
     addEventListener(
         keyboardMacro.onBeginWrappedCommand,
-        function() {
-            typingDetector.suspend();
+        function(wrapMode) {
+            if (wrapMode === 'side-effect') {
+                typingDetector.setAloneEnabled(true);
+            } else {
+                typingDetector.suspend();
+            }
         }
     );
     addEventListener(
         keyboardMacro.onEndWrappedCommand,
-        function() {
-            typingDetector.resume();
+        function(wrapMode) {
+            if (wrapMode === 'side-effect') {
+                typingDetector.setAloneEnabled(false);
+            } else {
+                typingDetector.resume();
+            }
         }
     );
     addEventListener(

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -190,7 +190,7 @@ const KeyboardMacro = function({ awaitController }) {
         args = validatePlaybackArgs(args);
         const repeat = 'repeat' in args ? args.repeat : 1;
         const commands = 'sequence' in args ? args.sequence : sequence.get();
-        const wrapMode = recording;
+        const wrapMode = recording ? 'command' : null;
         if (recording) {
             if (!('sequence' in args)) {
                 return;
@@ -198,7 +198,7 @@ const KeyboardMacro = function({ awaitController }) {
         }
         try {
             if (wrapMode && onBeginWrappedCommandCallback) {
-                onBeginWrappedCommandCallback();
+                onBeginWrappedCommandCallback(wrapMode);
             }
             changePlaybackState(true, PlaybackStateReason.Start);
             shouldAbortPlayback = false;
@@ -233,7 +233,7 @@ const KeyboardMacro = function({ awaitController }) {
             changePlaybackState(false, reason);
             shouldAbortPlayback = false;
             if (wrapMode && onEndWrappedCommandCallback) {
-                onEndWrappedCommandCallback();
+                onEndWrappedCommandCallback(wrapMode);
             }
         }
     };
@@ -287,9 +287,9 @@ const KeyboardMacro = function({ awaitController }) {
                 await playbackImpl(spec.args);
                 return;
             }
-            const sideEffectMode = spec.record === 'side-effect';
-            if (!sideEffectMode && onBeginWrappedCommandCallback) {
-                onBeginWrappedCommandCallback();
+            const wrapMode = spec.record || 'command';
+            if (onBeginWrappedCommandCallback) {
+                onBeginWrappedCommandCallback(wrapMode);
             }
             try {
                 const ok = await invokeCommandSync(spec, 'wrap');
@@ -297,8 +297,8 @@ const KeyboardMacro = function({ awaitController }) {
                     push(spec);
                 }
             } finally {
-                if (!sideEffectMode && onEndWrappedCommandCallback) {
-                    onEndWrappedCommandCallback();
+                if (onEndWrappedCommandCallback) {
+                    onEndWrappedCommandCallback(wrapMode);
                 }
             }
         }

--- a/src/typing_detector.js
+++ b/src/typing_detector.js
@@ -190,6 +190,7 @@ const TypingDetector = function() {
         stop,
         suspend,
         resume,
+        setAloneEnabled: cursorMotionDetector.setAloneEnabled,
         processDocumentChangeEvent,
         processSelectionChangeEvent : cursorMotionDetector.processSelectionChangeEvent,
         setPrediction: cursorMotionDetector.setPrediction, // testing purpose only

--- a/test/suite/cursor_motion_detector.test.js
+++ b/test/suite/cursor_motion_detector.test.js
@@ -56,12 +56,13 @@ describe('CursorMotionDetector', () => {
             assert.ok(cursorMotionDetector.getPrediction(textEditor1));
         });
     });
-    const testDetection = function({ init, lineLength = null, inputs, expectedLogs }) {
+    const testDetection = function({ init, lineLength = null, inputs, expectedLogs, enableAlone = false }) {
         const logs = [];
         const cursorMotionDetector = CursorMotionDetector();
         cursorMotionDetector.onDetectCursorMotion((type, args) => {
             logs.push([ type, args ]);
         });
+        cursorMotionDetector.setAloneEnabled(enableAlone);
         const textEditor = {
             selections: init
         };
@@ -270,6 +271,7 @@ describe('CursorMotionDetector', () => {
     describe('implicit motion without prediction', () => {
         it('should detect the unexpected motion of cursor (move to left)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 6, 3, 6) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 5, 3, 5) ] }
@@ -279,6 +281,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect the unexpected motion of cursor (move to right)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 6, 3, 6) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 7, 3, 7) ] }
@@ -288,6 +291,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect the unexpected motion of multi-cursor', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 6, 3, 6), new vscode.Selection(4, 6, 4, 6) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 7, 3, 7), new vscode.Selection(4, 7, 4, 7) ] }
@@ -298,6 +302,7 @@ describe('CursorMotionDetector', () => {
 
         it('should detect implicit motion (split into multi-cursor)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 7, 3, 7) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 10, 3, 10), new vscode.Selection(3, 12, 3, 12) ] }
@@ -307,6 +312,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect implicit motion (split multi to multi)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [
                     new vscode.Selection(3, 7, 3, 7),
                     new vscode.Selection(6, 7, 6, 7)
@@ -322,6 +328,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect implicit motion (split into multi-cursor on different lines) (1)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 7, 3, 7) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 10, 3, 10), new vscode.Selection(5, 2, 5, 2) ] }
@@ -331,6 +338,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect implicit motion (split into multi-cursor on different lines) (2)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [
                     new vscode.Selection(3, 7, 3, 7),
                     new vscode.Selection(6, 7, 6, 7)
@@ -346,6 +354,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect implicit motion (split into multi-cursor with selection)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 7, 3, 7) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 10, 3, 13), new vscode.Selection(3, 12, 3, 15) ] }
@@ -355,6 +364,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should ignore implicit motion with splitting to non-uniform selection length', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 7, 3, 7) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 10, 3, 13), new vscode.Selection(3, 12, 3, 16) ] }
@@ -365,6 +375,7 @@ describe('CursorMotionDetector', () => {
 
         it('should detect grouped cursor motion (1)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 7, 3, 7), new vscode.Selection(4, 7, 4, 7) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 8, 3, 8), new vscode.Selection(4, 9, 4, 9) ] }
@@ -374,6 +385,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect grouped cursor motion (2)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 7, 3, 7), new vscode.Selection(4, 7, 4, 7) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 8, 3, 8), new vscode.Selection(5, 8, 5, 8) ] }
@@ -383,6 +395,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect grouped cursor motion (3)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 7, 3, 7), new vscode.Selection(4, 7, 4, 7) ],
                 inputs: [
                     { changed: [ new vscode.Selection(3, 8, 3, 8) ] }
@@ -392,6 +405,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect grouped cursor motion (4)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 7, 3, 7), new vscode.Selection(4, 7, 4, 7) ],
                 inputs: [
                     { changed: [ new vscode.Selection(4, 3, 4, 3), new vscode.Selection(6, 3, 6, 3) ] }
@@ -401,6 +415,7 @@ describe('CursorMotionDetector', () => {
         });
         it('should detect grouped cursor motion (5)', async () => {
             testDetection({
+                enableAlone: true,
                 init: [ new vscode.Selection(3, 7, 3, 7), new vscode.Selection(6, 7, 6, 7) ],
                 inputs: [
                     { changed: [
@@ -409,6 +424,17 @@ describe('CursorMotionDetector', () => {
                     ] }
                 ],
                 expectedLogs: [[ CursorMotionType.Alone, GroupMotion(2, [3, 5, 10, 11], [0, 0, 3, 3]) ]]
+            });
+        });
+
+        it('should ignore unexpected cursor motion if aloneEnabled=false', async () => {
+            testDetection({
+                enableAlone: false,
+                init: [ new vscode.Selection(3, 6, 3, 6) ],
+                inputs: [
+                    { changed: [ new vscode.Selection(3, 7, 3, 7) ] }
+                ],
+                expectedLogs: []
             });
         });
     });

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -555,9 +555,9 @@ describe('KeybaordMacro', () => {
                 { command: 'internal:log', args: 'world' }
             ]);
         });
-        it('should call onBegin/EndWrappedCommand callback if called during recording', async () => {
-            keyboardMacro.onBeginWrappedCommand(() => { logs.push('onbeginwrap'); });
-            keyboardMacro.onEndWrappedCommand(() => { logs.push('onendwrap'); });
+        it('should call onBegin/EndWrappedCommand callback with wrapMode="command" if called during recording', async () => {
+            keyboardMacro.onBeginWrappedCommand((wrapMode) => { logs.push(`onbeginwrap: ${wrapMode}`); });
+            keyboardMacro.onEndWrappedCommand((wrapMode) => { logs.push(`onendwrap: ${wrapMode}`); });
             const sequence = [
                 { command: 'internal:log', args: 'hello' },
                 { command: 'internal:log', args: 'world' }
@@ -567,12 +567,12 @@ describe('KeybaordMacro', () => {
             keyboardMacro.finishRecording();
 
             assert.deepStrictEqual(logs, [
-                'onbeginwrap',
+                'onbeginwrap: command',
                 'begin:"hello"',
                 'end',
                 'begin:"world"',
                 'end',
-                'onendwrap'
+                'onendwrap: command'
             ]);
             assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), [
                 { command: 'internal:log', args: 'hello' },
@@ -850,18 +850,18 @@ describe('KeybaordMacro', () => {
 
             assert.deepStrictEqual(logs, []);
         });
-        it('should call onBegin/EndWrappedCommand callback', async () => {
-            keyboardMacro.onBeginWrappedCommand(() => { logs.push('onbeginwrap'); });
-            keyboardMacro.onEndWrappedCommand(() => { logs.push('onendwrap'); });
+        it('should call onBegin/EndWrappedCommand callback with wrapMode="command"', async () => {
+            keyboardMacro.onBeginWrappedCommand((wrapMode) => { logs.push(`onbeginwrap: ${wrapMode}`); });
+            keyboardMacro.onEndWrappedCommand((wrapMode) => { logs.push(`onendwrap: ${wrapMode}`); });
             keyboardMacro.startRecording();
             await keyboardMacro.wrapSync({ command: 'internal:log' });
             keyboardMacro.finishRecording();
 
             assert.deepStrictEqual(logs, [
-                'onbeginwrap',
+                'onbeginwrap: command',
                 'begin',
                 'end',
-                'onendwrap'
+                'onendwrap: command'
             ]);
             assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), [
                 { command: 'internal:log' },
@@ -1000,16 +1000,18 @@ describe('KeybaordMacro', () => {
             assert.deepStrictEqual(logs, [ 'begin', 'end' ]);
             assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), []);
         });
-        it('should not call onBegin/EndWrappedCommand callback if side-effect mode', async () => {
-            keyboardMacro.onBeginWrappedCommand(() => { logs.push('onbeginwrap'); });
-            keyboardMacro.onEndWrappedCommand(() => { logs.push('onendwrap'); });
+        it('should call onBegin/EndWrappedCommand callback with wrapMode="side-effect" if side-effect mode', async () => {
+            keyboardMacro.onBeginWrappedCommand((wrapMode) => { logs.push(`onbeginwrap: ${wrapMode}`); });
+            keyboardMacro.onEndWrappedCommand((wrapMode) => { logs.push(`onendwrap: ${wrapMode}`); });
             keyboardMacro.startRecording();
             await keyboardMacro.wrapSync({ command: 'internal:log', record: 'side-effect' });
             keyboardMacro.finishRecording();
 
             assert.deepStrictEqual(logs, [
+                'onbeginwrap: side-effect',
                 'begin',
-                'end'
+                'end',
+                'onendwrap: side-effect'
             ]);
             assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), []);
         });


### PR DESCRIPTION
Part of #33.

This PR adds a more precise mechanism of cursor motion detection for recording.

For example:
- A cursor motion in snippet mode triggered by the TAB key must be recorded for playback.
- A cursor motion in the document that happens when the find input box is focused and the user types on it must not be recorded.

This PR fixes the second case, and that is the main issue of #33.
To distinguish between the two types of detected cursor motions, we have already added a tracking mechanism for the type of the first case. See #76.
