### PR TITLE
Update keymap wrapper for Awesome Emacs Keymap (v0.41.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
   - Updated default keybindings based on VS Code 1.66.0. [#87](https://github.com/tshino/vscode-kb-macro/pull/87)
   - Updated default keybindings based on VS Code 1.65.2. [#74](https://github.com/tshino/vscode-kb-macro/pull/74)
   - Updated keymap wrapper for Awesome Emacs Keymap (v0.41.1). [#81](https://github.com/tshino/vscode-kb-macro/pull/81)
+  - Updated keymap wrapper for Awesome Emacs Keymap (v0.41.2). [#91](https://github.com/tshino/vscode-kb-macro/pull/91)
   - Updated Keymap wrapper for Delphi Keymap (v9.5.0). [#90](https://github.com/tshino/vscode-kb-macro/pull/90)
 - Internal
   - Added `record` option to the `kb-macro.wrap` command. [#76](https://github.com/tshino/vscode-kb-macro/pull/76)

--- a/keymap-wrapper/README.md
+++ b/keymap-wrapper/README.md
@@ -17,7 +17,7 @@ Click the keymap wrapper link in the table below, which opens a JSON file. Copy 
 | Keymap extension | Keymap wrapper | Last updated | Start recording | Stop recording | Playback |
 | ---------------- | -------------- | ------------ | ---------- | --------- | -------- |
 | [Atom Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.atom-keybindings) | [link](ms-vscode.atom-keybindings.json) | 2021-12-24 | `Ctrl+Alt+R` | `Ctrl+Alt+R` | `Ctrl+Alt+P` |
-| [Awesome Emacs Keymap](https://marketplace.visualstudio.com/items?itemName=tuttieee.emacs-mcx) | [link](tuttieee.emacs-mcx.json) | 2022-03-24 | `C-x S-9` | `C-x S-0` | `C-x e` |
+| [Awesome Emacs Keymap](https://marketplace.visualstudio.com/items?itemName=tuttieee.emacs-mcx) | [link](tuttieee.emacs-mcx.json) | 2022-04-04 | `C-x S-9` | `C-x S-0` | `C-x e` |
 | [Delphi Keymap](https://marketplace.visualstudio.com/items?itemName=alefragnani.delphi-keybindings) | [link](alefragnani.delphi-keybindings.json) | 2022-04-04 | `Ctrl/Cmd+Shift+R` | `Ctrl/Cmd+Shift+R` | `Ctrl/Cmd+Shift+P` |
 | [Notepad++ Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.notepadplusplus-keybindings) | [link](ms-vscode.notepadplusplus-keybindings.json) | 2021-12-26 | `Ctrl+Shift+R` | `Ctrl+Shift+R` | `Ctrl+Shift+P` |
 | [Sublime Text Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.sublime-keybindings) | [link](ms-vscode.sublime-keybindings.json) | 2021-12-21 | `Ctrl/Cmd+Q` | `Ctrl/Cmd+Q` | `Ctrl/Cmd+Shift+Q` |

--- a/keymap-wrapper/tuttieee.emacs-mcx.config.json
+++ b/keymap-wrapper/tuttieee.emacs-mcx.config.json
@@ -1,7 +1,7 @@
 {
     "base": {
         "type": "url",
-        "url": "https://github.com/whitphx/vscode-emacs-mcx/raw/v0.41.1/package.json"
+        "url": "https://github.com/whitphx/vscode-emacs-mcx/raw/v0.41.2/package.json"
     },
     "awaitOptions": [
         [ "emacs-mcx.forwardChar", "selection" ],

--- a/keymap-wrapper/tuttieee.emacs-mcx.json
+++ b/keymap-wrapper/tuttieee.emacs-mcx.json
@@ -1,5 +1,5 @@
 [
-	// Keymap wrapper for Awesome Emacs Keymap v0.41.1
+	// Keymap wrapper for Awesome Emacs Keymap v0.41.2
 	// (required by Keyboard Macro Beta)
 	// The latest version can be found at:
 	// https://github.com/tshino/vscode-kb-macro/blob/main/keymap-wrapper/README.md


### PR DESCRIPTION
Nothing has changed but the version number.