### PR TITLE
Exclude ctrl+tab from wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
   - Update default keybindings wrappers based on vscode 1.67.2. [#108](https://github.com/tshino/vscode-kb-macro/pull/108)
   - Update default keybindings wrappers based on vscode 1.68.0. [#117](https://github.com/tshino/vscode-kb-macro/pull/117)
   - Updated keymap wrapper for Vz Keymap (v0.19.2). [#118](https://github.com/tshino/vscode-kb-macro/pull/118)
+- Fix
+  - Fixed: `ctrl+tab` doesn't work correctly with this extension installed. [#119](https://github.com/tshino/vscode-kb-macro/issues/119)
 - Internal
   - Added summary output for the automated workflow. [#102](https://github.com/tshino/vscode-kb-macro/pull/102)
   - Enabled github-actions version updates with Dependabot.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ With this Visual Studio Code extension, you can record and playback your keyboar
   - Mouse inputs
   - Command execution via Command Palette
   - Menu navigation (even if you use acceralator keys)
-  - Widget/Popup UI navigation (e.g. Find and replace widget, IntelliSense popup)
+  - Widget/Popup UI navigation (e.g. Quick Picks, Find and replace widget, IntelliSense popup, )
     - Typing on the find/replace input box is not recorded, but shortcut keys like Enter/F3 (Find Next) hit on the widget are recorded.
     - Selecting items on suggest widget (even with arrow keys) are not recorded, however, once you accept one of the items and the text is inserted into the document, that is recorded as if you typed it directly.
   - IME nagivation
@@ -143,7 +143,7 @@ After you have successfully recorded a sequence, you may also save it for future
 | Task | Recordable ways to do it |
 | ---- | ------------------------ |
 | Move focus to editor | Instead of mouse, use `ctrl+1` (`cmd+1` for Mac) |
-| Switch to another tab | Instead of `ctrl+tab`, use `ctrl+pageup`/`ctrl+pagedown` (`alt+cmd+left`/`alt+cmd+right` for Mac) |
+| Switch editor tabs | Instead of `ctrl+tab`, use `ctrl+pageup`/`ctrl+pagedown` (`alt+cmd+left`/`alt+cmd+right` for Mac) |
 
 ## Commands
 ### For recording

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ With this Visual Studio Code extension, you can record and playback your keyboar
   - Mouse inputs
   - Command execution via Command Palette
   - Menu navigation (even if you use acceralator keys)
-  - Widget/Popup UI navigation (e.g. Quick Picks, Find and replace widget, IntelliSense popup, )
+  - Widget/Popup UI navigation (e.g. Quick Picks, Find and replace widget, IntelliSense popup)
     - Typing on the find/replace input box is not recorded, but shortcut keys like Enter/F3 (Find Next) hit on the widget are recorded.
     - Selecting items on suggest widget (even with arrow keys) are not recorded, however, once you accept one of the items and the text is inserted into the document, that is recorded as if you typed it directly.
   - IME nagivation

--- a/generator/config.json
+++ b/generator/config.json
@@ -16,7 +16,11 @@
     "exclusion": [
         "workbench.action.showCommands",
         "showPrevParameterHint",
-        "showNextParameterHint"
+        "showNextParameterHint",
+        "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup",
+        "workbench.action.quickOpenLeastRecentlyUsedEditorInGroup",
+        "workbench.action.quickOpenNavigateNextInEditorPicker",
+        "workbench.action.quickOpenNavigatePreviousInEditorPicker"
     ],
     "awaitOptions": [
         [ "editor.action.clipboardCopyAction", "clipboard" ],

--- a/keymap-wrapper/README.md
+++ b/keymap-wrapper/README.md
@@ -22,7 +22,7 @@ Click the keymap wrapper link in the table below, which opens a JSON file. Copy 
 | [Notepad++ Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.notepadplusplus-keybindings) | [link](ms-vscode.notepadplusplus-keybindings.json) | 2021-12-26 | `Ctrl+Shift+R` | `Ctrl+Shift+R` | `Ctrl+Shift+P` |
 | [Sublime Text Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.sublime-keybindings) | [link](ms-vscode.sublime-keybindings.json) | 2021-12-21 | `Ctrl/Cmd+Q` | `Ctrl/Cmd+Q` | `Ctrl/Cmd+Shift+Q` |
 | [Visual Studio Keymap](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vs-keybindings) | [link](ms-vscode.vs-keybindings.json) | 2022-04-05 | `Ctrl+M R` | `Ctrl+M R` | `Ctrl+M Enter` |
-| [Vz Keymap](https://marketplace.visualstudio.com/items?itemName=tshino.vz-like-keymap) | [link](tshino.vz-like-keymap.json) | 2022-06-11 | `Ctrl+_` | `Ctrl+^` | `Ctrl+^` |
+| [Vz Keymap](https://marketplace.visualstudio.com/items?itemName=tshino.vz-like-keymap) | [link](tshino.vz-like-keymap.json) | 2022-06-12 | `Ctrl+_` | `Ctrl+^` | `Ctrl+^` |
 
 - Each keyboard shortcut for start/stop recording and playback is assigned to the same ones that the original editor is using, as much as possible.
 - You can find the definitions of them at the bottom of each keymap wrapper file (find the `startRecording` command etc.). You can customize them as you like.

--- a/keymap-wrapper/tshino.vz-like-keymap.json
+++ b/keymap-wrapper/tshino.vz-like-keymap.json
@@ -387,7 +387,7 @@
 		"when": "kb-macro.recording && !multipleEditorGroups && groupEditorsCount == 1 && !sideBarFocus && !panelFocus && config.vzKeymap.alt+Y" },
 	{ "key": "alt+y", "command": "kb-macro.wrap", "args": { "command": "workbench.action.joinTwoGroups" },
 		"when": "kb-macro.recording && multipleEditorGroups && !sideBarFocus && !panelFocus && config.vzKeymap.alt+Y" },
-	{ "key": "alt+w", "command": "kb-macro.wrap", "args": { "command": "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup" },
+	{ "key": "alt+w", "command": "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup",
 		"when": "kb-macro.recording && !multipleEditorGroups && !sideBarFocus && !panelFocus && !findWidgetVisible && config.vzKeymap.alt+W" },
 	{ "key": "alt+w", "command": "kb-macro.wrap", "args": { "command": "workbench.action.focusNextGroup" },
 		"when": "kb-macro.recording && multipleEditorGroups && !sideBarFocus && !panelFocus && !findWidgetVisible && config.vzKeymap.alt+W" },

--- a/package.json
+++ b/package.json
@@ -5940,34 +5940,22 @@
 			},
 			{
 				"key": "ctrl+shift+tab",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "workbench.action.quickOpenLeastRecentlyUsedEditorInGroup"
-				},
+				"command": "workbench.action.quickOpenLeastRecentlyUsedEditorInGroup",
 				"when": "kb-macro.recording && !activeEditorGroupEmpty"
 			},
 			{
 				"key": "ctrl+shift+tab",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "workbench.action.quickOpenNavigatePreviousInEditorPicker"
-				},
+				"command": "workbench.action.quickOpenNavigatePreviousInEditorPicker",
 				"when": "kb-macro.recording && inEditorsPicker && inQuickOpen"
 			},
 			{
 				"key": "ctrl+tab",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup"
-				},
+				"command": "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup",
 				"when": "kb-macro.recording && !activeEditorGroupEmpty"
 			},
 			{
 				"key": "ctrl+tab",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "workbench.action.quickOpenNavigateNextInEditorPicker"
-				},
+				"command": "workbench.action.quickOpenNavigateNextInEditorPicker",
 				"when": "kb-macro.recording && inEditorsPicker && inQuickOpen"
 			},
 			{


### PR DESCRIPTION
Fixes #119 

This PR removes commands triggered by `ctrl+tab` or `ctrl+shift+tab` from keybindings wrappers.
They were causing issue #119.

It seems that the commands rely on the popup UI called Quick Pick.
Even if you simply want to switch to the next editor tab by `ctrl+tab`, the menu opens, and when you release the `ctrl` key the focused item is selected and the selected tab opens.
The behavior when releasing `ctrl` seems to be built-in to Quick Pick.

This extension cannot cover to record and playback navigations on Quick Pick UI. For example, `UpArrow`/`DownArrow` to select items, `Enter`/`Space` to accept an item, are not handled by the Keybindings system of vscode. Thus, they are not able to be recorded or to playback by an extension.