### PR TITLE
Don't pass undefined as 2nd argument of executeCommand()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Keyboard Macro Bata extension will be documented in this file.
 
+### [Unreleased]
+- Fix
+  - Fixed: `ctrl+shift+f` fails to focus Search in recording mode. [#142](https://github.com/tshino/vscode-kb-macro/issues/142)
+
 ### [0.12.4] - 2022-08-06
 - Update
   - Updated default keybindings wrappers based on vscode 1.70.0. [#135](https://github.com/tshino/vscode-kb-macro/pull/135)

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -142,10 +142,19 @@ const KeyboardMacro = function({ awaitController }) {
         if (func !== undefined) {
             await func(spec.args);
         } else {
-            await vscode.commands.executeCommand(
-                spec.command,
-                spec.args
-            );
+            // Passing an unnecessary second argument even if it's `undefined` can cause
+            // unexpected behavior of the target command.
+            // https://github.com/tshino/vscode-kb-macro/issues/142
+            if (spec.args === undefined) {
+                await vscode.commands.executeCommand(
+                    spec.command
+                );
+            } else {
+                await vscode.commands.executeCommand(
+                    spec.command,
+                    spec.args
+                );
+            }
         }
     };
 


### PR DESCRIPTION
Fixes #142 