### PR TITLE
Stop using deprecated set-output command in Github Actions workflow

### DIFF
--- a/.github/workflows/get-default-keybindings.yml
+++ b/.github/workflows/get-default-keybindings.yml
@@ -64,11 +64,11 @@ jobs:
         shell: bash
         run: |
           if git diff --exit-code; then
-            echo "::set-output name=has-diff::false"
+            echo "has-diff=false" >> $GITHUB_OUTPUT
             echo "No diff found"
             echo "### No diff found :+1:" >> $GITHUB_STEP_SUMMARY
           else
-            echo "::set-output name=has-diff::true"
+            echo "has-diff=true" >> $GITHUB_OUTPUT
           fi
       - name: Extract version numbers
         id: ver
@@ -80,9 +80,9 @@ jobs:
           echo "ver_linux: ${ver_linux}"
           echo "ver_macos: ${ver_macos}"
           echo "ver_windows: ${ver_windows}"
-          echo "::set-output name=linux::${ver_linux}"
-          echo "::set-output name=macos::${ver_macos}"
-          echo "::set-output name=windows::${ver_windows}"
+          echo "linux=${ver_linux}" >> $GITHUB_OUTPUT
+          echo "macos=${ver_macos}" >> $GITHUB_OUTPUT
+          echo "windows=${ver_windows}" >> $GITHUB_OUTPUT
           echo "Versions:" >> $GITHUB_STEP_SUMMARY
           echo "- VS Code for Linux: ${ver_linux}" >> $GITHUB_STEP_SUMMARY
           echo "- VS Code for macOS: ${ver_macos}" >> $GITHUB_STEP_SUMMARY
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           datetime=$(date +'%Y-%m-%d-%H-%M')
-          echo "::set-output name=branch-name::update-default-keybinding-${datetime}"
+          echo "branch-name=update-default-keybinding-${datetime}" >> $GITHUB_OUTPUT
       - name: Make a commit and push a branch
         if: steps.diff.outputs.has-diff == 'true'
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Keyboard Macro Bata extension will be documented in this file.
 
+### [Unreleased]
+- Internal:
+  - Updated automated workflow to stop using deprecated 'set-output' commands. [#156](https://github.com/tshino/vscode-kb-macro/pull/156)
+
 ### [0.12.7] - 2022-10-09
 - Update
   - Updated default keybindings wrappers based on vscode 1.72.0. [#151](https://github.com/tshino/vscode-kb-macro/pull/151)


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
