### PR TITLE
Fix code action keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
 ### [Unreleased]
 - Update
   - Updated default keybindings wrappers based on vscode 1.74.1. [#172](https://github.com/tshino/vscode-kb-macro/pull/172)
+- Fix
+  - Fixed: Some keybindings related to Code Action, which cannot be played back, were being recorded.
 
 ### [0.12.9] - 2022-12-10
 - Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Keyboard Macro Bata extension will be documented in t
 - Update
   - Updated default keybindings wrappers based on vscode 1.74.1. [#172](https://github.com/tshino/vscode-kb-macro/pull/172)
 - Fix
-  - Fixed: Some keybindings related to Code Action, which cannot be played back, were being recorded.
+  - Fixed: Some keybindings related to Code Action, which cannot be played back, were being recorded. [#173](https://github.com/tshino/vscode-kb-macro/pull/173)
 
 ### [0.12.9] - 2022-12-10
 - Update

--- a/generator/config.json
+++ b/generator/config.json
@@ -20,7 +20,13 @@
         "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup",
         "workbench.action.quickOpenLeastRecentlyUsedEditorInGroup",
         "workbench.action.quickOpenNavigateNextInEditorPicker",
-        "workbench.action.quickOpenNavigatePreviousInEditorPicker"
+        "workbench.action.quickOpenNavigatePreviousInEditorPicker",
+        "editor.action.quickFix",
+        "acceptSelectedCodeAction",
+        "hideCodeActionWidget",
+        "previewSelectedCodeAction",
+        "selectNextCodeAction",
+        "selectPrevCodeAction"
     ],
     "awaitOptions": [
         [ "editor.action.clipboardCopyAction", "clipboard" ],
@@ -70,7 +76,7 @@
                     "text": "\n"
                 }
             },
-            "when": "kb-macro.recording && editorTextFocus && !editorReadonly && !suggestWidgetVisible && !renameInputVisible"
+            "when": "kb-macro.recording && editorTextFocus && !editorReadonly && !suggestWidgetVisible && !renameInputVisible && !codeActionMenuVisible"
         }
     ],
     "footer": [

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 						"text": "\n"
 					}
 				},
-				"when": "kb-macro.recording && editorTextFocus && !editorReadonly && !suggestWidgetVisible && !renameInputVisible"
+				"when": "kb-macro.recording && editorTextFocus && !editorReadonly && !suggestWidgetVisible && !renameInputVisible && !codeActionMenuVisible"
 			},
 			{
 				"key": "escape escape",
@@ -281,10 +281,7 @@
 			},
 			{
 				"key": "shift+escape",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "hideCodeActionWidget"
-				},
+				"command": "hideCodeActionWidget",
 				"when": "kb-macro.recording && codeActionMenuVisible"
 			},
 			{
@@ -700,10 +697,7 @@
 			},
 			{
 				"key": "escape",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "hideCodeActionWidget"
-				},
+				"command": "hideCodeActionWidget",
 				"when": "kb-macro.recording && codeActionMenuVisible"
 			},
 			{
@@ -919,10 +913,7 @@
 			},
 			{
 				"key": "down",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "selectNextCodeAction"
-				},
+				"command": "selectNextCodeAction",
 				"when": "kb-macro.recording && codeActionMenuVisible"
 			},
 			{
@@ -1605,10 +1596,7 @@
 			},
 			{
 				"key": "up",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "selectPrevCodeAction"
-				},
+				"command": "selectPrevCodeAction",
 				"when": "kb-macro.recording && codeActionMenuVisible"
 			},
 			{
@@ -2030,12 +2018,9 @@
 			},
 			{
 				"key": "ctrl+down",
-				"mac": "cmd+down",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "selectNextCodeAction"
-				},
-				"when": "kb-macro.recording && codeActionMenuVisible"
+				"command": "selectNextCodeAction",
+				"when": "kb-macro.recording && codeActionMenuVisible",
+				"mac": "cmd+down"
 			},
 			{
 				"key": "ctrl+up",
@@ -2109,12 +2094,9 @@
 			},
 			{
 				"key": "ctrl+up",
-				"mac": "cmd+up",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "selectPrevCodeAction"
-				},
-				"when": "kb-macro.recording && codeActionMenuVisible"
+				"command": "selectPrevCodeAction",
+				"when": "kb-macro.recording && codeActionMenuVisible",
+				"mac": "cmd+up"
 			},
 			{
 				"key": "alt+pagedown",
@@ -2833,10 +2815,7 @@
 			},
 			{
 				"key": "enter",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "acceptSelectedCodeAction"
-				},
+				"command": "acceptSelectedCodeAction",
 				"when": "kb-macro.recording && codeActionMenuVisible"
 			},
 			{
@@ -3632,12 +3611,9 @@
 			},
 			{
 				"key": "ctrl+enter",
-				"mac": "cmd+enter",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "previewSelectedCodeAction"
-				},
-				"when": "kb-macro.recording && codeActionMenuVisible"
+				"command": "previewSelectedCodeAction",
+				"when": "kb-macro.recording && codeActionMenuVisible",
+				"mac": "cmd+enter"
 			},
 			{
 				"key": "ctrl+shift+enter",
@@ -3986,12 +3962,9 @@
 			},
 			{
 				"key": "ctrl+.",
-				"mac": "cmd+.",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "editor.action.quickFix"
-				},
-				"when": "kb-macro.recording && editorHasCodeActionsProvider && editorTextFocus && !editorReadonly"
+				"command": "editor.action.quickFix",
+				"when": "kb-macro.recording && editorHasCodeActionsProvider && editorTextFocus && !editorReadonly",
+				"mac": "cmd+."
 			},
 			{
 				"key": "ctrl+.",
@@ -4013,12 +3986,9 @@
 			},
 			{
 				"key": "ctrl+.",
-				"mac": "cmd+.",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "acceptSelectedCodeAction"
-				},
-				"when": "kb-macro.recording && codeActionMenuVisible"
+				"command": "acceptSelectedCodeAction",
+				"when": "kb-macro.recording && codeActionMenuVisible",
+				"mac": "cmd+."
 			},
 			{
 				"key": "ctrl+shift+r",
@@ -7232,10 +7202,7 @@
 			},
 			{
 				"key": "ctrl+n",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "selectNextCodeAction"
-				},
+				"command": "selectNextCodeAction",
 				"when": "kb-macro.recording && isMac && codeActionMenuVisible"
 			},
 			{
@@ -7382,10 +7349,7 @@
 			},
 			{
 				"key": "ctrl+p",
-				"command": "kb-macro.wrap",
-				"args": {
-					"command": "selectPrevCodeAction"
-				},
+				"command": "selectPrevCodeAction",
 				"when": "kb-macro.recording && isMac && codeActionMenuVisible"
 			},
 			{


### PR DESCRIPTION
Some keybindings related to Code Action were being recorded.
Code Actions cannot be captured or played back using VS Code API.
So, the keybindings should be excluded from wrappers.
