### PR TITLE
Fix background recording condition

### DIFF
--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -137,7 +137,7 @@ const KeyboardMacro = function({ awaitController }) {
             // side-effect mode
             return;
         }
-        if (active) {
+        if (backgroundRecording) {
             history.push(spec);
         }
         if (recording) {

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -1241,6 +1241,14 @@ describe('KeybaordMacro', () => {
                 { command: 'internal:log' }
             ]);
         });
+        it('should not create history without background recording even if in explicit recording mode', async () => {
+            keyboardMacro.startRecording();
+            await keyboardMacro.wrapSync({ command: 'internal:log' });
+            await keyboardMacro.wrapSync({ command: 'internal:log' });
+            keyboardMacro.finishRecording();
+
+            assert.deepStrictEqual(keyboardMacro.getHistory(), []);
+        });
         it('should invoke commands in a playback with explicit sequence option and not record them as explicit recording', async () => {
             await keyboardMacro.enableBackgroundRecording();
             await keyboardMacro.playback(


### PR DESCRIPTION
This is a part of the implementation of Background recording API #176.

This PR fixes the condition of whether the history is created.

There are two independent concepts related to recording.

1. Explicit recording mode
    - This mode starts or stops by the user's action via the commands `kb-macro.startRecording`, `kb-macro.finishRecording` etc.
2. Background recording mode
    - This mode starts or stops by other extensions through API (not yet implemented though).

These modes should be able to be turned on and off independently. As a result, there are four possible different states:

| state | context | note |
| ----- | ------- | ---- |
| idle | `!kb-macro.recording && !kb-macro.active` | no recording |
| explicit | `kb-macro.recording && kb-macro.active` | macro recording only |
| background | `!kb-macro.recording && kb-macro.active` | history recording only |
| background and explicit | `kb-macro.recording && kb-macro.active` | both history and macro recording |

The second and fourth have the same context representation, but that is okay at this moment because the background recording is an internal mode.