### PR TITLE
Add background recording API

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -11,6 +11,11 @@ const keyboardMacro = KeyboardMacro({ awaitController });
 const typingDetector = TypingDetector();
 const helperContext = HelperContext();
 
+const api = {
+    startBackgroundRecording: keyboardMacro.startBackgroundRecording,
+    stopBackgroundRecording: keyboardMacro.stopBackgroundRecording
+};
+
 function activate(context) {
     const CommandPrefix = 'kb-macro.';
     const ContextPrefix = 'kb-macro.';
@@ -167,10 +172,6 @@ function activate(context) {
 
     helperContext.reset(vscode.window.activeTextEditor);
 
-    const api = {
-        startBackgroundRecording: keyboardMacro.startBackgroundRecording,
-        stopBackgroundRecording: keyboardMacro.stopBackgroundRecording
-    };
     return api;
 }
 
@@ -179,6 +180,9 @@ function deactivate() {}
 module.exports = {
     activate,
     deactivate,
+
+    // for testing
     awaitController,
-    keyboardMacro
+    keyboardMacro,
+    api,
 };

--- a/src/extension.js
+++ b/src/extension.js
@@ -166,6 +166,12 @@ function activate(context) {
     );
 
     helperContext.reset(vscode.window.activeTextEditor);
+
+    const api = {
+        enableBackgroundRecording: keyboardMacro.enableBackgroundRecording,
+        disableBackgroundRecording: keyboardMacro.disableBackgroundRecording
+    };
+    return api;
 }
 
 function deactivate() {}

--- a/src/extension.js
+++ b/src/extension.js
@@ -168,8 +168,8 @@ function activate(context) {
     helperContext.reset(vscode.window.activeTextEditor);
 
     const api = {
-        startBackgroundRecording: keyboardMacro.enableBackgroundRecording,
-        stopBackgroundRecording: keyboardMacro.disableBackgroundRecording
+        startBackgroundRecording: keyboardMacro.startBackgroundRecording,
+        stopBackgroundRecording: keyboardMacro.stopBackgroundRecording
     };
     return api;
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -168,8 +168,8 @@ function activate(context) {
     helperContext.reset(vscode.window.activeTextEditor);
 
     const api = {
-        enableBackgroundRecording: keyboardMacro.enableBackgroundRecording,
-        disableBackgroundRecording: keyboardMacro.disableBackgroundRecording
+        startBackgroundRecording: keyboardMacro.enableBackgroundRecording,
+        stopBackgroundRecording: keyboardMacro.disableBackgroundRecording
     };
     return api;
 }

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -383,7 +383,7 @@ const KeyboardMacro = function({ awaitController }) {
 
         // testing purpose only
         isRecording: () => { return recording; },
-        isBackgroundRecordingEnabled: () => { return backgroundRecording; },
+        isBackgroundRecordingOngoing: () => { return backgroundRecording; },
         isPlaying: () => { return playing; },
         getCurrentSequence: () => { return sequence.get(); },
         getHistory: () => { return history.get(); },

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -118,7 +118,7 @@ const KeyboardMacro = function({ awaitController }) {
             changeRecordingState(false, RecordingStateReason.Finish);
         }
     });
-    const enableBackgroundRecording = async function() {
+    const startBackgroundRecording = async function() {
         await reentrantGuard.callExclusively(function() {
             if (!backgroundRecording) {
                 history.clear();
@@ -126,7 +126,7 @@ const KeyboardMacro = function({ awaitController }) {
             }
         });
     };
-    const disableBackgroundRecording = async function() {
+    const stopBackgroundRecording = async function() {
         await reentrantGuard.callExclusively(function() {
             changeBackgroundRecordingState(false);
         });
@@ -369,8 +369,8 @@ const KeyboardMacro = function({ awaitController }) {
         startRecording,
         cancelRecording,
         finishRecording,
-        enableBackgroundRecording,
-        disableBackgroundRecording,
+        startBackgroundRecording,
+        stopBackgroundRecording,
         push,
         copyMacroAsKeybinding,
         validatePlaybackArgs,

--- a/test/suite/api.test.js
+++ b/test/suite/api.test.js
@@ -1,0 +1,20 @@
+'use strict';
+const assert = require('assert');
+const { api } = require('../../src/extension.js');
+
+describe('api', () => {
+    describe('startBackgroundRecording', () => {
+        it('should be an async function', () => {
+            const func = api.startBackgroundRecording;
+            assert.strictEqual(typeof func, 'function');
+            assert.strictEqual(func.constructor.name, 'AsyncFunction');
+        });
+    });
+    describe('stopBackgroundRecording', () => {
+        it('should be an async function', () => {
+            const func = api.stopBackgroundRecording;
+            assert.strictEqual(typeof func, 'function');
+            assert.strictEqual(func.constructor.name, 'AsyncFunction');
+        });
+    });
+});

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -1063,7 +1063,7 @@ describe('KeybaordMacro', () => {
             keyboardMacro.onChangeActiveState(null);
             logs.length = 0;
         });
-        it('should enable background recording mode', async () => {
+        it('should start background recording mode', async () => {
             assert.strictEqual(keyboardMacro.isBackgroundRecordingOngoing(), false);
             await keyboardMacro.startBackgroundRecording();
             assert.strictEqual(keyboardMacro.isBackgroundRecordingOngoing(), true);
@@ -1072,7 +1072,7 @@ describe('KeybaordMacro', () => {
             await keyboardMacro.startBackgroundRecording();
             assert.deepStrictEqual(logs, ['active:true']);
         });
-        it('should be ignored if already enabled', async () => {
+        it('should be ignored if already started', async () => {
             await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.startBackgroundRecording();
             assert.deepStrictEqual(logs, ['active:true']);
@@ -1128,7 +1128,7 @@ describe('KeybaordMacro', () => {
             keyboardMacro.onChangeActiveState(null);
             logs.length = 0;
         });
-        it('should disable background recording mode', async () => {
+        it('should stop background recording mode', async () => {
             await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.stopBackgroundRecording();
             assert.strictEqual(keyboardMacro.isBackgroundRecordingOngoing(), false);
@@ -1139,7 +1139,7 @@ describe('KeybaordMacro', () => {
             await keyboardMacro.stopBackgroundRecording();
             assert.deepStrictEqual(logs, ['active:false']);
         });
-        it('should be ignored if already disabled', async () => {
+        it('should be ignored if already stopped', async () => {
             await keyboardMacro.startBackgroundRecording();
             logs.length = 0;
             await keyboardMacro.stopBackgroundRecording();

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -1064,9 +1064,9 @@ describe('KeybaordMacro', () => {
             logs.length = 0;
         });
         it('should enable background recording mode', async () => {
-            assert.strictEqual(keyboardMacro.isBackgroundRecordingEnabled(), false);
+            assert.strictEqual(keyboardMacro.isBackgroundRecordingOngoing(), false);
             await keyboardMacro.startBackgroundRecording();
-            assert.strictEqual(keyboardMacro.isBackgroundRecordingEnabled(), true);
+            assert.strictEqual(keyboardMacro.isBackgroundRecordingOngoing(), true);
         });
         it('should turn active context on', async () => {
             await keyboardMacro.startBackgroundRecording();
@@ -1131,7 +1131,7 @@ describe('KeybaordMacro', () => {
         it('should disable background recording mode', async () => {
             await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.stopBackgroundRecording();
-            assert.strictEqual(keyboardMacro.isBackgroundRecordingEnabled(), false);
+            assert.strictEqual(keyboardMacro.isBackgroundRecordingOngoing(), false);
         });
         it('should turn active context off', async () => {
             await keyboardMacro.startBackgroundRecording();

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -52,8 +52,8 @@ describe('KeybaordMacro', () => {
             keyboardMacro.finishRecording();
             keyboardMacro.startRecording();
             keyboardMacro.cancelRecording();
-            await keyboardMacro.enableBackgroundRecording();
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
 
             assert.deepStrictEqual(logs, [
                 true,
@@ -1041,7 +1041,7 @@ describe('KeybaordMacro', () => {
             assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), []);
         });
     });
-    describe('enableBackgroundRecording', () => {
+    describe('startBackgroundRecording', () => {
         const logs = [];
         beforeEach(async () => {
             keyboardMacro.onChangeRecordingState(({ recording }) => {
@@ -1057,7 +1057,7 @@ describe('KeybaordMacro', () => {
             });
         });
         afterEach(async () => {
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             keyboardMacro.cancelRecording();
             keyboardMacro.onChangeRecordingState(null);
             keyboardMacro.onChangeActiveState(null);
@@ -1065,48 +1065,48 @@ describe('KeybaordMacro', () => {
         });
         it('should enable background recording mode', async () => {
             assert.strictEqual(keyboardMacro.isBackgroundRecordingEnabled(), false);
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             assert.strictEqual(keyboardMacro.isBackgroundRecordingEnabled(), true);
         });
         it('should turn active context on', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             assert.deepStrictEqual(logs, ['active:true']);
         });
         it('should be ignored if already enabled', async () => {
-            await keyboardMacro.enableBackgroundRecording();
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             assert.deepStrictEqual(logs, ['active:true']);
         });
         it('should be combined with recording state to control active context', async () => {
             keyboardMacro.startRecording();
             assert.deepStrictEqual(logs, ['recording:true', 'active:true']);
             logs.length = 0;
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             assert.deepStrictEqual(logs, []);
             logs.length = 0;
             keyboardMacro.finishRecording();
             assert.deepStrictEqual(logs, ['recording:false']);
             logs.length = 0;
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             assert.deepStrictEqual(logs, ['active:false']);
         });
         it('should defer starting background recording mode until ongoing wrapper ends (inside explicit recording)', async () => {
             keyboardMacro.startRecording();
             logs.length = 0;
             const promise1 = keyboardMacro.wrapSync({ command: 'internal:log' });
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             assert.deepStrictEqual(logs, [ 'begin', 'end' ]);
             await promise1;
             keyboardMacro.finishRecording();
         });
         it('should defer starting background recording mode until ongoing playback ends (out of explicit recording)', async () => {
             const promise1 = keyboardMacro.playback({ sequence: [ { command: 'internal:log' } ] });
-            const promise2 = keyboardMacro.enableBackgroundRecording();
+            const promise2 = keyboardMacro.startBackgroundRecording();
             await Promise.all([promise1, promise2]);
             assert.deepStrictEqual(logs, [ 'begin', 'end', 'active:true' ]);
         });
     });
-    describe('disableBackgroundRecording', () => {
+    describe('stopBackgroundRecording', () => {
         const logs = [];
         beforeEach(async () => {
             keyboardMacro.onChangeRecordingState(({ recording }) => {
@@ -1122,66 +1122,66 @@ describe('KeybaordMacro', () => {
             });
         });
         afterEach(async () => {
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             keyboardMacro.cancelRecording();
             keyboardMacro.onChangeRecordingState(null);
             keyboardMacro.onChangeActiveState(null);
             logs.length = 0;
         });
         it('should disable background recording mode', async () => {
-            await keyboardMacro.enableBackgroundRecording();
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             assert.strictEqual(keyboardMacro.isBackgroundRecordingEnabled(), false);
         });
         it('should turn active context off', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             logs.length = 0;
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             assert.deepStrictEqual(logs, ['active:false']);
         });
         it('should be ignored if already disabled', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             logs.length = 0;
-            await keyboardMacro.disableBackgroundRecording();
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             assert.deepStrictEqual(logs, ['active:false']);
         });
         it('should be combined with recording state to control active context', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             assert.deepStrictEqual(logs, ['active:true']);
             logs.length = 0;
             keyboardMacro.startRecording();
             assert.deepStrictEqual(logs, ['recording:true']);
             logs.length = 0;
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             assert.deepStrictEqual(logs, []);
             logs.length = 0;
             keyboardMacro.finishRecording();
             assert.deepStrictEqual(logs, ['recording:false', 'active:false']);
         });
         it('should defer stopping background recording mode until ongoing wrapper ends (inside explicit recording)', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             keyboardMacro.startRecording();
             logs.length = 0;
             const promise1 = keyboardMacro.wrapSync({ command: 'internal:log' });
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             assert.deepStrictEqual(logs, [ 'begin', 'end' ]);
             await promise1;
             keyboardMacro.finishRecording();
         });
         it('should defer stopping background recording mode until ongoing wrapper ends (out of explicit recording)', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             logs.length = 0;
             const promise1 = keyboardMacro.wrapSync({ command: 'internal:log' });
-            const promise2 = keyboardMacro.disableBackgroundRecording();
+            const promise2 = keyboardMacro.stopBackgroundRecording();
             await Promise.all([promise1, promise2]);
             assert.deepStrictEqual(logs, [ 'begin', 'end', 'active:false' ]);
         });
         it('should defer stopping background recording mode until ongoing playback ends (out of explicit recording)', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             logs.length = 0;
             const promise1 = keyboardMacro.playback({ sequence: [ { command: 'internal:log' } ] });
-            const promise2 = keyboardMacro.disableBackgroundRecording();
+            const promise2 = keyboardMacro.stopBackgroundRecording();
             await Promise.all([promise1, promise2]);
             assert.deepStrictEqual(logs, [ 'begin', 'end', 'active:false' ]);
         });
@@ -1206,7 +1206,7 @@ describe('KeybaordMacro', () => {
             });
         });
         afterEach(async () => {
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             keyboardMacro.cancelRecording();
             keyboardMacro.onChangeActiveState(null);
             keyboardMacro.onBeginWrappedCommand(null);
@@ -1215,10 +1215,10 @@ describe('KeybaordMacro', () => {
             logs.length = 0;
         });
         it('should invoke wrapped commands and not record them as explicit recording', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.wrapSync({ command: 'internal:log' });
             await keyboardMacro.wrapSync({ command: 'internal:log' });
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
 
             assert.deepStrictEqual(logs, [
                 'active:true',
@@ -1231,10 +1231,10 @@ describe('KeybaordMacro', () => {
             assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), []);
         });
         it('should record wrapped commands as history', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.wrapSync({ command: 'internal:log' });
             await keyboardMacro.wrapSync({ command: 'internal:log' });
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
 
             assert.deepStrictEqual(keyboardMacro.getHistory(), [
                 { command: 'internal:log' },
@@ -1250,14 +1250,14 @@ describe('KeybaordMacro', () => {
             assert.deepStrictEqual(keyboardMacro.getHistory(), []);
         });
         it('should invoke commands in a playback with explicit sequence option and not record them as explicit recording', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.playback(
                 { sequence: [
                     { command: 'internal:log' },
                     { command: 'internal:log' }
                 ] }
             );
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
 
             assert.deepStrictEqual(logs, [
                 'active:true',
@@ -1276,10 +1276,10 @@ describe('KeybaordMacro', () => {
             logs.length = 0;
 
             const sequenceBeforePlayback = Array.from(keyboardMacro.getCurrentSequence());
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.playback();
             await keyboardMacro.playback();
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             const sequenceAfterPlayback = Array.from(keyboardMacro.getCurrentSequence());
 
             assert.deepStrictEqual(logs, [
@@ -1293,14 +1293,14 @@ describe('KeybaordMacro', () => {
             assert.deepStrictEqual(sequenceAfterPlayback, sequenceBeforePlayback);
         });
         it('should record commands in a playback with explicit sequence option as history', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.playback(
                 { sequence: [
                     { command: 'internal:log' },
                     { command: 'internal:log' }
                 ] }
             );
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
 
             assert.deepStrictEqual(keyboardMacro.getHistory(), [
                 { command: 'internal:log' },
@@ -1313,10 +1313,10 @@ describe('KeybaordMacro', () => {
             await keyboardMacro.wrapSync({ command: 'internal:log' });
             keyboardMacro.finishRecording();
 
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.playback();
             await keyboardMacro.playback();
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
 
             assert.deepStrictEqual(keyboardMacro.getHistory(), [
                 { command: 'internal:log' },
@@ -1330,9 +1330,9 @@ describe('KeybaordMacro', () => {
             await keyboardMacro.wrapSync({ command: 'internal:log' });
             keyboardMacro.finishRecording();
 
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.playback({ repeat: 2 });
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
 
             assert.deepStrictEqual(keyboardMacro.getHistory(), [
                 { command: 'internal:log' },
@@ -1340,11 +1340,11 @@ describe('KeybaordMacro', () => {
             ]);
         });
         it('should discard history when background recording starts', async () => {
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await keyboardMacro.wrapSync({ command: 'internal:log' });
             await keyboardMacro.wrapSync({ command: 'internal:log' });
-            await keyboardMacro.disableBackgroundRecording();
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
 
             assert.deepStrictEqual(keyboardMacro.getHistory(), []);
         });

--- a/test/suite/playback_typing.test.js
+++ b/test/suite/playback_typing.test.js
@@ -722,18 +722,18 @@ describe('Recording and Playback: Typing', () => {
         });
         it('should detect and reproduce direct typing of a character', async () => {
             await setSelections([[0, 0]]);
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await vscode.commands.executeCommand('type', { text: 'X' });
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             assert.deepStrictEqual(keyboardMacro.getHistory(), [ Type('X') ]);
             assert.strictEqual(textEditor.document.lineAt(0).text, 'X');
             assert.deepStrictEqual(getSelections(), [[0, 1]]);
         });
         it('should record typing of an opening bracket which triggers bracket completion', async () => {
             await setSelections([[10, 4]]);
-            await keyboardMacro.enableBackgroundRecording();
+            await keyboardMacro.startBackgroundRecording();
             await vscode.commands.executeCommand('type', { text: '(' });
-            await keyboardMacro.disableBackgroundRecording();
+            await keyboardMacro.stopBackgroundRecording();
             assert.deepStrictEqual(keyboardMacro.getHistory(), [ Type('()'), MoveLeft(1) ]);
             assert.strictEqual(textEditor.document.lineAt(10).text, 'abcd()');
             assert.deepStrictEqual(getSelections(), [[10, 5]]);


### PR DESCRIPTION
This is a part of the implementation of Background recording API #176.

This PR adds the API functions.
- `startBackgroundRecording`
- `stopBackgroundRecording`

