### PR TITLE
History API

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -13,7 +13,8 @@ const helperContext = HelperContext();
 
 const api = {
     startBackgroundRecording: keyboardMacro.startBackgroundRecording,
-    stopBackgroundRecording: keyboardMacro.stopBackgroundRecording
+    stopBackgroundRecording: keyboardMacro.stopBackgroundRecording,
+    getRecentBackgroundRecords: keyboardMacro.getRecentBackgroundRecords,
 };
 
 function activate(context) {

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -131,6 +131,9 @@ const KeyboardMacro = function({ awaitController }) {
             changeBackgroundRecordingState(false);
         });
     };
+    const getRecentBackgroundRecords = function() {
+        return history.get();
+    };
 
     const push = function(spec) {
         if (spec.record === 'side-effect') {
@@ -371,6 +374,7 @@ const KeyboardMacro = function({ awaitController }) {
         finishRecording,
         startBackgroundRecording,
         stopBackgroundRecording,
+        getRecentBackgroundRecords,
         push,
         copyMacroAsKeybinding,
         validatePlaybackArgs,

--- a/test/suite/api.test.js
+++ b/test/suite/api.test.js
@@ -17,4 +17,11 @@ describe('api', () => {
             assert.strictEqual(func.constructor.name, 'AsyncFunction');
         });
     });
+    describe('getRecentBackgroundRecords', () => {
+        it('should be a function', () => {
+            const func = api.getRecentBackgroundRecords;
+            assert.strictEqual(typeof func, 'function');
+            assert.strictEqual(func.constructor.name, 'Function');
+        });
+    });
 });

--- a/test/suite/api.test.js
+++ b/test/suite/api.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const assert = require('assert');
-const { api } = require('../../src/extension.js');
+const { api, keyboardMacro } = require('../../src/extension.js');
 
 describe('api', () => {
     describe('startBackgroundRecording', () => {
@@ -18,10 +18,36 @@ describe('api', () => {
         });
     });
     describe('getRecentBackgroundRecords', () => {
-        it('should be a function', () => {
+        beforeEach(async () => {
+            await api.stopBackgroundRecording();
+            keyboardMacro.discardHistory();
+        });
+        it('should be a non-async function', () => {
             const func = api.getRecentBackgroundRecords;
             assert.strictEqual(typeof func, 'function');
             assert.strictEqual(func.constructor.name, 'Function');
+        });
+        it('should return the recent records of background recording', async () => {
+            await api.startBackgroundRecording();
+            await keyboardMacro.wrapSync({
+                command: 'workbench.action.togglePanel'
+            });
+            await keyboardMacro.wrapSync({
+                command: 'workbench.action.toggleSidebarVisibility'
+            });
+            await api.stopBackgroundRecording();
+
+            assert.deepStrictEqual(
+                api.getRecentBackgroundRecords(),
+                [
+                    {
+                        command: 'workbench.action.togglePanel'
+                    },
+                    {
+                        command: 'workbench.action.toggleSidebarVisibility'
+                    }
+                ]
+            );
         });
     });
 });


### PR DESCRIPTION
This is a part of the implementation of History API #177.

This PR adds a new API:
- `getRecentBackgroundRecords`
