### PR TITLE
Record comparison API

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -15,6 +15,7 @@ const api = {
     startBackgroundRecording: keyboardMacro.startBackgroundRecording,
     stopBackgroundRecording: keyboardMacro.stopBackgroundRecording,
     getRecentBackgroundRecords: keyboardMacro.getRecentBackgroundRecords,
+    areEqualRecords: keyboardMacro.areEqualRecords,
 };
 
 function activate(context) {

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -135,6 +135,14 @@ const KeyboardMacro = function({ awaitController }) {
         const sequence = history.get();
         return JSON.parse(JSON.stringify(sequence));
     };
+    const areEqualRecords = function(record1, record2) {
+        const spec1 = util.makeCommandSpec(record1);
+        const spec2 = util.makeCommandSpec(record2);
+        if (!spec1 || !spec2) {
+            return null;
+        }
+        return util.areEqualCommandSpec(spec1, spec2);
+    };
 
     const push = function(spec) {
         if (spec.record === 'side-effect') {
@@ -376,6 +384,7 @@ const KeyboardMacro = function({ awaitController }) {
         startBackgroundRecording,
         stopBackgroundRecording,
         getRecentBackgroundRecords,
+        areEqualRecords,
         push,
         copyMacroAsKeybinding,
         validatePlaybackArgs,

--- a/src/util.js
+++ b/src/util.js
@@ -82,13 +82,43 @@ const util = (function() {
         return spec;
     };
 
+    const areEqualCommandSpec = function(spec1, spec2) {
+        if (spec1 === spec2) {
+            return true;
+        }
+        if (spec1.command !== spec2.command) {
+            return false;
+        }
+        if (
+            ('args' in spec1) !== ('args' in spec2) ||
+            typeof spec1.args !== typeof spec2.args ||
+            JSON.stringify(spec1.args) !== JSON.stringify(spec2.args)
+        ) {
+            return false;
+        }
+        if (
+            ('await' in spec1) !== ('await' in spec2) ||
+            spec1.await !== spec2.await
+        ) {
+            return false;
+        }
+        if (
+            ('record' in spec1) !== ('record' in spec2) ||
+            spec1.record !== spec2.record
+        ) {
+            return false;
+        }
+        return true;
+    };
+
     return {
         isEqualSelections,
         sortSelections,
         makeIndexOfSortedSelections,
         makeSelectionsAfterTyping,
         validatePositiveIntegerInput,
-        makeCommandSpec
+        makeCommandSpec,
+        areEqualCommandSpec
     };
 })();
 

--- a/test/suite/api.test.js
+++ b/test/suite/api.test.js
@@ -50,4 +50,24 @@ describe('api', () => {
             );
         });
     });
+    describe('areEqualRecords', () => {
+        it('should return true if given two records are equal', () => {
+            const record1 = { command: 'c1' };
+            const record2 = { command: 'c1' };
+
+            assert.strictEqual(api.areEqualRecords(record1, record2), true);
+        });
+        it('should return false if given two records are not equal', () => {
+            const record1 = { command: 'c1' };
+            const record2 = { command: 'c2' };
+
+            assert.strictEqual(api.areEqualRecords(record1, record2), false);
+        });
+        it('should return null for invalid arguments', () => {
+            assert.strictEqual(api.areEqualRecords(null, null), null);
+            assert.strictEqual(api.areEqualRecords({}, {}), null);
+            assert.strictEqual(api.areEqualRecords({}, undefined), null);
+            assert.strictEqual(api.areEqualRecords({ command: 1234 }, { command: 1234 }), null);
+        });
+    });
 });

--- a/test/suite/util.test.js
+++ b/test/suite/util.test.js
@@ -255,4 +255,57 @@ describe('util', () => {
             );
         });
     });
+    describe('areEqualCommandSpec', () => {
+        it('should return true only if given two specs are equal', () => {
+            assert.strictEqual(util.areEqualCommandSpec(
+                { command: 'a' },
+                { command: 'a' }
+            ), true);
+            assert.strictEqual(util.areEqualCommandSpec(
+                { command: 'a', args: 123 },
+                { command: 'a', args: 123 }
+            ), true);
+            assert.strictEqual(util.areEqualCommandSpec(
+                { command: 'a', args: [ 1, 2, 3] },
+                { command: 'a', args: [ 1, 2, 3] }
+            ), true);
+            assert.strictEqual(util.areEqualCommandSpec(
+                { command: 'a', args: { x: 123 } },
+                { command: 'a', args: { x: 123 } }
+            ), true);
+            assert.strictEqual(util.areEqualCommandSpec(
+                { command: 'a', await: 'selection' },
+                { command: 'a', await: 'selection' }
+            ), true);
+            assert.strictEqual(util.areEqualCommandSpec(
+                { command: 'a', record: 'side-effect' },
+                { command: 'a', record: 'side-effect' }
+            ), true);
+        });
+        it('should return false if given two specs are not equal', () => {
+            const s1 = { command: 'a' };
+            const s2 = { command: 'b' };
+            const s3 = { command: 'a', args: 123 };
+            const s4 = { command: 'a', args: [ 1, 2, 3 ] };
+            const s5 = { command: 'a', args: [ 1, 2, 3, 4 ] };
+            const s6 = { command: 'a', args: { x: 123 } };
+            const s7 = { command: 'a', args: { x: 456 } };
+            const s8 = { command: 'a', await: 'document' };
+            const s9 = { command: 'a', await: 'document selection' };
+            const s10 = { command: 'a', record: '' };
+            const s11 = { command: 'a', record: 'side-effect' };
+
+            assert.strictEqual(util.areEqualCommandSpec(s1, s2), false);
+            assert.strictEqual(util.areEqualCommandSpec(s1, s3), false);
+            assert.strictEqual(util.areEqualCommandSpec(s3, s4), false);
+            assert.strictEqual(util.areEqualCommandSpec(s3, s6), false);
+            assert.strictEqual(util.areEqualCommandSpec(s4, s5), false);
+            assert.strictEqual(util.areEqualCommandSpec(s4, s6), false);
+            assert.strictEqual(util.areEqualCommandSpec(s6, s7), false);
+            assert.strictEqual(util.areEqualCommandSpec(s1, s8), false);
+            assert.strictEqual(util.areEqualCommandSpec(s8, s9), false);
+            assert.strictEqual(util.areEqualCommandSpec(s1, s10), false);
+            assert.strictEqual(util.areEqualCommandSpec(s10, s11), false);
+        });
+    });
 });


### PR DESCRIPTION
This is a part of #177.

This PR adds a new API:
- `areEqualRecords`
