### PR TITLE
Optimize input sequence in playback command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Keyboard Macro Bata extension will be documented in this file.
 
 ### [Unreleased]
+- Feature:
+  - Added optimization of the input sequence to the playback command. [#195](https://github.com/tshino/vscode-kb-macro/pull/195)
+    - This optimization can improve playback performance, especially in a sequence containing a long typing.
 - Update
   - Changed the activatation context of wrapper keybindings from `kb-macro.recording` to `kb-macro.active`. [#133](https://github.com/tshino/vscode-kb-macro/issues/133)
     - This change does not require any actions for existing users unless they want to use the extra feature Background Recording API.

--- a/src/command_sequence.js
+++ b/src/command_sequence.js
@@ -55,8 +55,10 @@ const CommandSequence = function({ maxLength = null } = {}) {
                     groupSize1 === 1 &&
                     characterDelta1 < 0 &&
                     characterDelta1 + deleteRight2 === 0) {
-                    sequence[i + 1].args.deleteLeft = deleteLeft2 + deleteRight2;
-                    delete sequence[i + 1].args.deleteRight;
+                    const args = JSON.parse(JSON.stringify(sequence[i + 1].args));
+                    args.deleteLeft = deleteLeft2 + deleteRight2;
+                    delete args.deleteRight;
+                    sequence[i + 1] = { command: '$type', args };
                     sequence.splice(i, 1);
                     i--;
                     continue;
@@ -76,7 +78,9 @@ const CommandSequence = function({ maxLength = null } = {}) {
                 if (text1.length >= deleteLeft2 &&
                     deleteRight2 === 0) {
                     const text = text1.substr(0, text1.length - deleteLeft2) + text2;
-                    sequence[i - 1].args.text = text;
+                    const args = JSON.parse(JSON.stringify(sequence[i - 1].args));
+                    args.text = text;
+                    sequence[i - 1] = { command: '$type', args };
                     sequence.splice(i, 1);
                     i--;
                     continue;

--- a/src/keyboard_macro.js
+++ b/src/keyboard_macro.js
@@ -244,11 +244,19 @@ const KeyboardMacro = function({ awaitController }) {
         }
         return validArgs;
     };
+    const optimizeSequence = function(sequence) {
+        const s = CommandSequence();
+        for (const command of sequence) {
+            s.push(command);
+        }
+        s.optimize();
+        return s.get();
+    };
 
     const playbackImpl = async function(args, { tillEndOfFile = false } = {}) {
         args = validatePlaybackArgs(args);
         const repeat = 'repeat' in args ? args.repeat : 1;
-        const commands = 'sequence' in args ? args.sequence : sequence.get();
+        const commands = 'sequence' in args ? optimizeSequence(args.sequence) : sequence.get();
         const wrapMode = active ? 'command' : null;
         if (recording) {
             if (!('sequence' in args)) {

--- a/test/suite/keyboard_macro.test.js
+++ b/test/suite/keyboard_macro.test.js
@@ -631,7 +631,7 @@ describe('KeybaordMacro', () => {
                 { command: 'internal:log', args: 'hello' }
             ]);
         });
-        it('should record the commands specified times if repeat option specified', async () => {
+        it('should record the commands multiple times if repeat option specified', async () => {
             const sequence = [
                 { command: 'internal:log', args: 'hello' }
             ];
@@ -652,6 +652,23 @@ describe('KeybaordMacro', () => {
                 { command: 'internal:log', args: 'hello' },
                 { command: 'internal:log', args: 'hello' },
                 { command: 'internal:log', args: 'hello' }
+            ]);
+        });
+        it('should optimize the specified sequence before executing and recording', async () => {
+            keyboardMacro.registerInternalCommand('$type', async (args) => {
+                logs.push(`$type:${args.text}`);
+            });
+            const sequence = [
+                { command: '$type', args: { text: 'A' } },
+                { command: '$type', args: { text: 'B' } }
+            ];
+            keyboardMacro.startRecording();
+            await keyboardMacro.playback({ sequence });
+            keyboardMacro.finishRecording();
+
+            assert.deepStrictEqual(logs, [ '$type:AB' ]);
+            assert.deepStrictEqual(keyboardMacro.getCurrentSequence(), [
+                { command: '$type', args: { text: 'AB' } }
             ]);
         });
     });


### PR DESCRIPTION
This PR is related to #176.

This PR adds optimization of the input sequence to the playback command.
For example, two consecutive '$type' commands will be concatenated into one and executed and recorded as one command.
This:
```
await vscode.commands.executeCommand(
    'kb-macro.playback',
    {
        sequence: [
            { command: '$type', args: { text: 'A' } },
            { command: '$type', args: { text: 'B' } }
        ]
    }
);
```
will be interpreted as:
```
await vscode.commands.executeCommand(
    'kb-macro.playback',
    {
        sequence: [
            { command: '$type', args: { text: 'AB' } }
        ]
    }
);
```
This optimization can improve playback performance, especially in a sequence containing a long typing.
