### PR TITLE
Add newSession API

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -11,12 +11,29 @@ const keyboardMacro = KeyboardMacro({ awaitController });
 const typingDetector = TypingDetector();
 const helperContext = HelperContext();
 
-const api = {
-    startBackgroundRecording: keyboardMacro.startBackgroundRecording,
-    stopBackgroundRecording: keyboardMacro.stopBackgroundRecording,
-    getRecentBackgroundRecords: keyboardMacro.getRecentBackgroundRecords,
-    areEqualRecords: keyboardMacro.areEqualRecords,
-};
+const api = (function() {
+    // This global session is a workaround for the early dynamic-macro extension.
+    // https://github.com/tshino/vscode-dynamic-macro
+    const globalSession = keyboardMacro.newSession();
+
+    return {
+        startBackgroundRecording: globalSession.startRecording,
+        stopBackgroundRecording: globalSession.stopRecording,
+        getRecentBackgroundRecords: globalSession.getRecentSequence,
+        areEqualRecords: keyboardMacro.areEqualRecords,
+
+        newSession: function() {
+            const session = keyboardMacro.newSession();
+            return {
+                startRecording: session.startRecording,
+                stopRecording: session.stopRecording,
+                getRecentSequence: session.getRecentSequence,
+                areEqualRecords: keyboardMacro.areEqualRecords,
+                close: session.close,
+            };
+        },
+    };
+})();
 
 function activate(context) {
     const CommandPrefix = 'kb-macro.';

--- a/test/suite/api.test.js
+++ b/test/suite/api.test.js
@@ -3,42 +3,89 @@ const assert = require('assert');
 const { api, keyboardMacro } = require('../../src/extension.js');
 
 describe('api', () => {
-    describe('startBackgroundRecording', () => {
-        it('should be an async function', () => {
-            const func = api.startBackgroundRecording;
-            assert.strictEqual(typeof func, 'function');
-            assert.strictEqual(func.constructor.name, 'AsyncFunction');
-        });
-    });
-    describe('stopBackgroundRecording', () => {
-        it('should be an async function', () => {
-            const func = api.stopBackgroundRecording;
-            assert.strictEqual(typeof func, 'function');
-            assert.strictEqual(func.constructor.name, 'AsyncFunction');
-        });
-    });
-    describe('getRecentBackgroundRecords', () => {
-        beforeEach(async () => {
-            await api.stopBackgroundRecording();
-            keyboardMacro.discardHistory();
+    describe('newSession', () => {
+        let session = null;
+        afterEach(async () => {
+            if (session) {
+                await session.close();
+                session = null;
+            }
         });
         it('should be a non-async function', () => {
-            const func = api.getRecentBackgroundRecords;
+            const func = api.newSession;
+            assert.strictEqual(typeof func, 'function');
+            assert.strictEqual(func.constructor.name, 'Function');
+        });
+        it('should create a new session with background recording APIs', () => {
+            session = api.newSession();
+            assert.strictEqual('startRecording' in session, true);
+            assert.strictEqual('stopRecording' in session, true);
+            assert.strictEqual('getRecentSequence' in session, true);
+            assert.strictEqual('areEqualRecords' in session, true);
+            assert.strictEqual('close' in session, true);
+        });
+    });
+    describe('workaround for early dynamic-macro extension', () => {
+        it('should have old style APIs', () => {
+            assert.strictEqual('startBackgroundRecording' in api, true);
+            assert.strictEqual('stopBackgroundRecording' in api, true);
+            assert.strictEqual('getRecentBackgroundRecords' in api, true);
+            assert.strictEqual('areEqualRecords' in api, true);
+        });
+    });
+    describe('session.startRecording', () => {
+        let session = null;
+        beforeEach(async () => {
+            session = api.newSession();
+        });
+        afterEach(async () => {
+            await session.close();
+        });
+        it('should be an async function', () => {
+            const func = session.startRecording;
+            assert.strictEqual(typeof func, 'function');
+            assert.strictEqual(func.constructor.name, 'AsyncFunction');
+        });
+    });
+    describe('session.stopRecording', () => {
+        let session = null;
+        beforeEach(async () => {
+            session = api.newSession();
+        });
+        afterEach(async () => {
+            await session.close();
+        });
+        it('should be an async function', () => {
+            const func = session.stopRecording;
+            assert.strictEqual(typeof func, 'function');
+            assert.strictEqual(func.constructor.name, 'AsyncFunction');
+        });
+    });
+    describe('session.getRecentSequence', () => {
+        let session = null;
+        beforeEach(async () => {
+            session = api.newSession();
+        });
+        afterEach(async () => {
+            await session.close();
+        });
+        it('should be a non-async function', () => {
+            const func = session.getRecentSequence;
             assert.strictEqual(typeof func, 'function');
             assert.strictEqual(func.constructor.name, 'Function');
         });
         it('should return the recent records of background recording', async () => {
-            await api.startBackgroundRecording();
+            await session.startRecording();
             await keyboardMacro.wrapSync({
                 command: 'workbench.action.togglePanel'
             });
             await keyboardMacro.wrapSync({
                 command: 'workbench.action.toggleSidebarVisibility'
             });
-            await api.stopBackgroundRecording();
+            await session.stopRecording();
 
             assert.deepStrictEqual(
-                api.getRecentBackgroundRecords(),
+                session.getRecentSequence(),
                 [
                     {
                         command: 'workbench.action.togglePanel'
@@ -50,24 +97,31 @@ describe('api', () => {
             );
         });
     });
-    describe('areEqualRecords', () => {
+    describe('session.areEqualRecords', () => {
+        let session = null;
+        beforeEach(async () => {
+            session = api.newSession();
+        });
+        afterEach(async () => {
+            await session.close();
+        });
         it('should return true if given two records are equal', () => {
             const record1 = { command: 'c1' };
             const record2 = { command: 'c1' };
 
-            assert.strictEqual(api.areEqualRecords(record1, record2), true);
+            assert.strictEqual(session.areEqualRecords(record1, record2), true);
         });
         it('should return false if given two records are not equal', () => {
             const record1 = { command: 'c1' };
             const record2 = { command: 'c2' };
 
-            assert.strictEqual(api.areEqualRecords(record1, record2), false);
+            assert.strictEqual(session.areEqualRecords(record1, record2), false);
         });
         it('should return null for invalid arguments', () => {
-            assert.strictEqual(api.areEqualRecords(null, null), null);
-            assert.strictEqual(api.areEqualRecords({}, {}), null);
-            assert.strictEqual(api.areEqualRecords({}, undefined), null);
-            assert.strictEqual(api.areEqualRecords({ command: 1234 }, { command: 1234 }), null);
+            assert.strictEqual(session.areEqualRecords(null, null), null);
+            assert.strictEqual(session.areEqualRecords({}, {}), null);
+            assert.strictEqual(session.areEqualRecords({}, undefined), null);
+            assert.strictEqual(session.areEqualRecords({ command: 1234 }, { command: 1234 }), null);
         });
     });
 });

--- a/test/suite/playback_typing.test.js
+++ b/test/suite/playback_typing.test.js
@@ -713,28 +713,33 @@ describe('Recording and Playback: Typing', () => {
     });
 
     describe('background recording of typing', () => {
+        let session = null;
         beforeEach(async () => {
             await TestUtil.resetDocument(textEditor, (
                 '\n'.repeat(10) +
                 'abcd\n'.repeat(10) +
                 '    efgh\n'.repeat(10)
             ));
+            session = keyboardMacro.newSession();
+        });
+        afterEach(async () => {
+            await session.close();
         });
         it('should detect and reproduce direct typing of a character', async () => {
             await setSelections([[0, 0]]);
-            await keyboardMacro.startBackgroundRecording();
+            await session.startRecording();
             await vscode.commands.executeCommand('type', { text: 'X' });
-            await keyboardMacro.stopBackgroundRecording();
-            assert.deepStrictEqual(keyboardMacro.getRecentBackgroundRecords(), [ Type('X') ]);
+            await session.stopRecording();
+            assert.deepStrictEqual(session.getRecentSequence(), [ Type('X') ]);
             assert.strictEqual(textEditor.document.lineAt(0).text, 'X');
             assert.deepStrictEqual(getSelections(), [[0, 1]]);
         });
         it('should record typing of an opening bracket which triggers bracket completion', async () => {
             await setSelections([[10, 4]]);
-            await keyboardMacro.startBackgroundRecording();
+            await session.startRecording();
             await vscode.commands.executeCommand('type', { text: '(' });
-            await keyboardMacro.stopBackgroundRecording();
-            assert.deepStrictEqual(keyboardMacro.getRecentBackgroundRecords(), [ Type('()'), MoveLeft(1) ]);
+            await session.stopRecording();
+            assert.deepStrictEqual(session.getRecentSequence(), [ Type('()'), MoveLeft(1) ]);
             assert.strictEqual(textEditor.document.lineAt(10).text, 'abcd()');
             assert.deepStrictEqual(getSelections(), [[10, 5]]);
         });


### PR DESCRIPTION
This is a part of #176.

This PR introduces a design change of API.
This PR adds a new `newSession` API.
And also replaces all of the already implemented APIs with a new style API.

This design change makes the state and the history of background recording separate for each API client.
Using the `newSession` API, multiple extensions can use the background recording API concurrently and independently.
