### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/get-default-keybindings.yml
+++ b/.github/workflows/get-default-keybindings.yml
@@ -8,6 +8,9 @@ on:
     - cron: '38 16 * * 5'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   get-default-keybindings:
 
@@ -43,6 +46,9 @@ jobs:
 
   check-for-diff:
     needs: get-default-keybindings
+    permissions:
+      contents: write
+      pull-requests: write
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/tshino/vscode-kb-macro/security/code-scanning/3](https://github.com/tshino/vscode-kb-macro/security/code-scanning/3)

Add explicit `permissions` in `.github/workflows/get-default-keybindings.yml`:

- Set a **workflow-level baseline** to least privilege: `contents: read`.
- Override only the `check-for-diff` job with the minimum extra rights it actually needs:
  - `contents: write` (for pushing branch commits)
  - `pull-requests: write` (for creating the PR via `gh pr create`)

This preserves functionality while enforcing least privilege and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
